### PR TITLE
TEST: DO NOT MERGE; try elm-format 0.8.4-rc1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,13 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+    
+      - name: Install elm-format 0.8.4-rc1
+        run: |
+          curl https://ipfs.globalupload.io/QmPoDMWqhsnddeb2qRPD6eoYFNhQrMyJhUkiggyMk1zp8h > elm-format.zip
+          unzip elm-format.zip
+          tar zxvf elm-format-0.8.4-rc1-linux-x64.tgz
+          mv elm-format node_modules/.bin/elm-format
 
       # Runs a single command using the runners shell
       - name: Elm Publish


### PR DESCRIPTION
This is just a hack to try out the rc elm-format.  This hack shouldn't be merged, as the elm-format dependency can be updated normally once it is officially published.