### PR TITLE
Improve NoUnused.Pattern error details

### DIFF
--- a/src/NoUnused/Patterns.elm
+++ b/src/NoUnused/Patterns.elm
@@ -330,7 +330,7 @@ findPatterns use (Node range pattern) =
             [ SimplifiablePattern
                 (Rule.errorWithFix
                     { message = "Tuple pattern is not needed."
-                    , details = removeDetails
+                    , details = redundantDetails
                     }
                     range
                     [ Fix.replaceRangeBy range "_" ]
@@ -341,7 +341,7 @@ findPatterns use (Node range pattern) =
             [ SimplifiablePattern
                 (Rule.errorWithFix
                     { message = "Tuple pattern is not needed."
-                    , details = removeDetails
+                    , details = redundantDetails
                     }
                     range
                     [ Fix.replaceRangeBy range "_" ]
@@ -369,7 +369,7 @@ findPatterns use (Node range pattern) =
                 [ SimplifiablePattern
                     (Rule.errorWithFix
                         { message = "Named pattern is not needed."
-                        , details = removeDetails
+                        , details = redundantDetails
                         }
                         range
                         [ Fix.replaceRangeBy range "_" ]
@@ -401,6 +401,11 @@ singularDetails =
 pluralDetails : List String
 pluralDetails =
     [ "You should either use these values somewhere, or remove them at the location I pointed at." ]
+
+
+redundantDetails : List String
+redundantDetails =
+    [ "This pattern is redundant and should be replaced with '_' at the location I pointed at." ]
 
 
 removeDetails : List String
@@ -481,7 +486,7 @@ errorsForUselessNamePattern : Range -> Context -> ( List (Rule.Error {}), Contex
 errorsForUselessNamePattern range context =
     ( [ Rule.errorWithFix
             { message = "Named pattern is not needed."
-            , details = removeDetails
+            , details = redundantDetails
             }
             range
             [ Fix.replaceRangeBy range "_" ]
@@ -494,7 +499,7 @@ errorsForUselessTuple : Range -> Context -> ( List (Rule.Error {}), Context )
 errorsForUselessTuple range context =
     ( [ Rule.errorWithFix
             { message = "Tuple pattern is not needed."
-            , details = removeDetails
+            , details = redundantDetails
             }
             range
             [ Fix.replaceRangeBy range "_" ]

--- a/src/NoUnused/Patterns.elm
+++ b/src/NoUnused/Patterns.elm
@@ -9,7 +9,6 @@ module NoUnused.Patterns exposing (rule)
 
 -}
 
-import Elm.Syntax.Declaration exposing (Declaration)
 import Elm.Syntax.Expression as Expression exposing (Expression)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node(..))

--- a/src/NoUnused/Patterns.elm
+++ b/src/NoUnused/Patterns.elm
@@ -320,7 +320,7 @@ findPatterns use (Node range pattern) =
             [ SingleValue
                 { name = name
                 , message = "Value `" ++ name ++ "` is not used."
-                , details = singularDetails
+                , details = singularReplaceDetails
                 , range = range
                 , fix = [ Fix.replaceRangeBy range "_" ]
                 }
@@ -393,9 +393,14 @@ findPatterns use (Node range pattern) =
 --- ON EXIT
 
 
-singularDetails : List String
-singularDetails =
+singularRemoveDetails : List String
+singularRemoveDetails =
     [ "You should either use this value somewhere, or remove it at the location I pointed at." ]
+
+
+singularReplaceDetails : List String
+singularReplaceDetails =
+    [ "You should either use this value somewhere, or replace it with '_' at the location I pointed at." ]
 
 
 pluralDetails : List String
@@ -566,7 +571,7 @@ listToDetails : String -> List String -> List String
 listToDetails _ rest =
     case rest of
         [] ->
-            singularDetails
+            singularRemoveDetails
 
         _ ->
             pluralDetails
@@ -586,7 +591,7 @@ errorsForAsPattern patternRange inner (Node range name) context =
         in
         ( [ Rule.errorWithFix
                 { message = "Pattern alias `" ++ name ++ "` is not used."
-                , details = singularDetails
+                , details = singularRemoveDetails
                 }
                 range
                 fix
@@ -634,7 +639,7 @@ findPatternForAsPattern patternRange inner (Node range name) =
         SingleValue
             { name = name
             , message = "Pattern alias `" ++ name ++ "` is not used."
-            , details = singularDetails
+            , details = singularRemoveDetails
             , range = range
             , fix = fix
             }
@@ -660,7 +665,7 @@ errorsForValue name range context =
     if isUnused name context then
         ( [ Rule.errorWithFix
                 { message = "Value `" ++ name ++ "` is not used."
-                , details = singularDetails
+                , details = singularReplaceDetails
                 }
                 range
                 [ Fix.replaceRangeBy range "_" ]

--- a/src/NoUnused/Patterns.elm
+++ b/src/NoUnused/Patterns.elm
@@ -395,27 +395,27 @@ findPatterns use (Node range pattern) =
 
 singularRemoveDetails : List String
 singularRemoveDetails =
-    [ "You should either use this value somewhere, or remove it at the location I pointed at." ]
+    [ "You should either use this value somewhere or remove it." ]
 
 
 singularReplaceDetails : List String
 singularReplaceDetails =
-    [ "You should either use this value somewhere, or replace it with '_' at the location I pointed at." ]
+    [ "You should either use this value somewhere or replace it with '_'." ]
 
 
 pluralDetails : List String
 pluralDetails =
-    [ "You should either use these values somewhere, or remove them at the location I pointed at." ]
+    [ "You should either use these values somewhere or remove them." ]
 
 
 redundantDetails : List String
 redundantDetails =
-    [ "This pattern is redundant and should be replaced with '_' at the location I pointed at." ]
+    [ "This pattern is redundant and should be replaced with '_'." ]
 
 
 removeDetails : List String
 removeDetails =
-    [ "You should remove it at the location I pointed at." ]
+    [ "This pattern is redundant and should be removed." ]
 
 
 andThen :

--- a/tests/NoUnused/PatternsTests.elm
+++ b/tests/NoUnused/PatternsTests.elm
@@ -5,8 +5,8 @@ import Review.Test
 import Test exposing (Test, describe, test)
 
 
-details : List String
-details =
+useOrRemoveDetails : List String
+useOrRemoveDetails =
     [ "You should either use this value somewhere, or remove it at the location I pointed at."
     ]
 
@@ -53,7 +53,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `bish` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "bish"
                         }
                         |> Review.Test.whenFixed
@@ -68,7 +68,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `bash` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "bash"
                         }
                         |> Review.Test.whenFixed
@@ -97,7 +97,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `one` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "one"
                         }
                         |> Review.Test.whenFixed
@@ -112,7 +112,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `first` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "first"
                         }
                         |> Review.Test.whenFixed
@@ -127,7 +127,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `two` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "two"
                         }
                         |> Review.Test.whenFixed
@@ -142,7 +142,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `more` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "more"
                         }
                         |> Review.Test.whenFixed
@@ -171,7 +171,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `one` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "one"
                         }
                         |> Review.Test.whenFixed
@@ -186,7 +186,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `first` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "first"
                         }
                         |> Review.Test.whenFixed
@@ -201,7 +201,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `two` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "two"
                         }
                         |> Review.Test.whenFixed
@@ -216,7 +216,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `more` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "more"
                         }
                         |> Review.Test.whenFixed
@@ -245,7 +245,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `foo` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "foo"
                         }
                         |> Review.Test.atExactly { start = { row = 7, column = 20 }, end = { row = 7, column = 23 } }
@@ -277,7 +277,7 @@ bar =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `bish` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "bish"
                         }
                         |> Review.Test.atExactly { start = { row = 9, column = 9 }, end = { row = 9, column = 13 } }
@@ -343,7 +343,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `right` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "right"
                         }
                         |> Review.Test.whenFixed
@@ -407,7 +407,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `right` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "right"
                         }
                         |> Review.Test.atExactly { start = { row = 13, column = 21 }, end = { row = 13, column = 26 } }
@@ -485,7 +485,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Pattern alias `bosh` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "bosh"
                         }
                         |> Review.Test.whenFixed
@@ -510,7 +510,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `bash` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "bash"
                         }
                         |> Review.Test.whenFixed
@@ -535,7 +535,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `bash` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "bash"
                         }
                         |> Review.Test.whenFixed
@@ -548,7 +548,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Pattern alias `bosh` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "bosh"
                         }
                         |> Review.Test.whenFixed
@@ -598,7 +598,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Pattern alias `bish` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "bish"
                         }
                         |> Review.Test.whenFixed
@@ -630,7 +630,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `first` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "first"
                         }
                         |> Review.Test.whenFixed
@@ -643,7 +643,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `second` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "second"
                         }
                         |> Review.Test.whenFixed
@@ -675,7 +675,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `bish` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "bish"
                         }
                         |> Review.Test.whenFixed
@@ -704,7 +704,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `bish` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "bish"
                         }
                         |> Review.Test.whenFixed
@@ -930,7 +930,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `bish` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "bish"
                         }
                         |> Review.Test.whenFixed
@@ -945,7 +945,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `bosh` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "bosh"
                         }
                         |> Review.Test.whenFixed
@@ -1046,7 +1046,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `first` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "first"
                         }
                         |> Review.Test.whenFixed
@@ -1059,7 +1059,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `rest` is not used."
-                        , details = details
+                        , details = useOrRemoveDetails
                         , under = "rest"
                         }
                         |> Review.Test.whenFixed

--- a/tests/NoUnused/PatternsTests.elm
+++ b/tests/NoUnused/PatternsTests.elm
@@ -10,10 +10,18 @@ useOrRemoveDetails =
     [ "You should either use this value somewhere, or remove it at the location I pointed at."
     ]
 
+
+useOrReplaceDetails : List String
+useOrReplaceDetails =
+    [ "You should either use this value somewhere, or replace it with '_' at the location I pointed at."
+    ]
+
+
 redundantReplaceDetails : List String
 redundantReplaceDetails =
     [ "This pattern is redundant and should be replaced with '_' at the location I pointed at."
     ]
+
 
 all : Test
 all =
@@ -53,7 +61,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `bish` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "bish"
                         }
                         |> Review.Test.whenFixed
@@ -68,7 +76,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `bash` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "bash"
                         }
                         |> Review.Test.whenFixed
@@ -97,7 +105,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `one` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "one"
                         }
                         |> Review.Test.whenFixed
@@ -112,7 +120,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `first` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "first"
                         }
                         |> Review.Test.whenFixed
@@ -127,7 +135,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `two` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "two"
                         }
                         |> Review.Test.whenFixed
@@ -142,7 +150,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `more` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "more"
                         }
                         |> Review.Test.whenFixed
@@ -171,7 +179,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `one` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "one"
                         }
                         |> Review.Test.whenFixed
@@ -186,7 +194,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `first` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "first"
                         }
                         |> Review.Test.whenFixed
@@ -201,7 +209,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `two` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "two"
                         }
                         |> Review.Test.whenFixed
@@ -216,7 +224,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `more` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "more"
                         }
                         |> Review.Test.whenFixed
@@ -245,7 +253,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `foo` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "foo"
                         }
                         |> Review.Test.atExactly { start = { row = 7, column = 20 }, end = { row = 7, column = 23 } }
@@ -277,7 +285,7 @@ bar =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `bish` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "bish"
                         }
                         |> Review.Test.atExactly { start = { row = 9, column = 9 }, end = { row = 9, column = 13 } }
@@ -343,7 +351,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `right` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "right"
                         }
                         |> Review.Test.whenFixed
@@ -407,7 +415,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `right` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "right"
                         }
                         |> Review.Test.atExactly { start = { row = 13, column = 21 }, end = { row = 13, column = 26 } }
@@ -630,7 +638,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `first` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "first"
                         }
                         |> Review.Test.whenFixed
@@ -643,7 +651,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `second` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "second"
                         }
                         |> Review.Test.whenFixed
@@ -675,7 +683,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `bish` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "bish"
                         }
                         |> Review.Test.whenFixed
@@ -704,7 +712,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `bish` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "bish"
                         }
                         |> Review.Test.whenFixed
@@ -930,7 +938,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `bish` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "bish"
                         }
                         |> Review.Test.whenFixed
@@ -945,7 +953,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `bosh` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "bosh"
                         }
                         |> Review.Test.whenFixed
@@ -1046,7 +1054,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Value `first` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "first"
                         }
                         |> Review.Test.whenFixed
@@ -1059,7 +1067,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Value `rest` is not used."
-                        , details = useOrRemoveDetails
+                        , details = useOrReplaceDetails
                         , under = "rest"
                         }
                         |> Review.Test.whenFixed

--- a/tests/NoUnused/PatternsTests.elm
+++ b/tests/NoUnused/PatternsTests.elm
@@ -7,19 +7,19 @@ import Test exposing (Test, describe, test)
 
 useOrRemoveDetails : List String
 useOrRemoveDetails =
-    [ "You should either use this value somewhere, or remove it at the location I pointed at."
+    [ "You should either use this value somewhere or remove it."
     ]
 
 
 useOrReplaceDetails : List String
 useOrReplaceDetails =
-    [ "You should either use this value somewhere, or replace it with '_' at the location I pointed at."
+    [ "You should either use this value somewhere or replace it with '_'."
     ]
 
 
 redundantReplaceDetails : List String
 redundantReplaceDetails =
-    [ "This pattern is redundant and should be replaced with '_' at the location I pointed at."
+    [ "This pattern is redundant and should be replaced with '_'."
     ]
 
 
@@ -379,7 +379,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Pattern `_` is not needed."
-                        , details = [ "You should remove it at the location I pointed at." ]
+                        , details = [ "This pattern is redundant and should be removed." ]
                         , under = "_"
                         }
                         |> Review.Test.whenFixed
@@ -580,7 +580,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Pattern `_` is not needed."
-                        , details = [ "You should remove it at the location I pointed at." ]
+                        , details = [ "This pattern is redundant and should be removed." ]
                         , under = "_"
                         }
                         |> Review.Test.whenFixed
@@ -846,7 +846,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Values `bish` and `bash` are not used."
-                        , details = [ "You should either use these values somewhere, or remove them at the location I pointed at." ]
+                        , details = [ "You should either use these values somewhere or remove them." ]
                         , under = "{ bish, bash }"
                         }
                         |> Review.Test.whenFixed
@@ -875,7 +875,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Values `bish` and `bosh` are not used."
-                        , details = [ "You should either use these values somewhere, or remove them at the location I pointed at." ]
+                        , details = [ "You should either use these values somewhere or remove them." ]
                         , under = "bish, bash, bosh"
                         }
                         |> Review.Test.whenFixed
@@ -904,7 +904,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Values `bash` and `bosh` are not used."
-                        , details = [ "You should either use these values somewhere, or remove them at the location I pointed at." ]
+                        , details = [ "You should either use these values somewhere or remove them." ]
                         , under = "bash, bosh"
                         }
                         |> Review.Test.whenFixed

--- a/tests/NoUnused/PatternsTests.elm
+++ b/tests/NoUnused/PatternsTests.elm
@@ -10,6 +10,10 @@ details =
     [ "You should either use this value somewhere, or remove it at the location I pointed at."
     ]
 
+redundantReplaceDetails : List String
+redundantReplaceDetails =
+    [ "This pattern is redundant and should be replaced with '_' at the location I pointed at."
+    ]
 
 all : Test
 all =
@@ -744,7 +748,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Named pattern is not needed."
-                        , details = [ "You should remove it at the location I pointed at." ]
+                        , details = redundantReplaceDetails
                         , under = "Singular _"
                         }
                         |> Review.Test.whenFixed
@@ -759,7 +763,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Named pattern is not needed."
-                        , details = [ "You should remove it at the location I pointed at." ]
+                        , details = redundantReplaceDetails
                         , under = "Pair _ _"
                         }
                         |> Review.Test.whenFixed
@@ -787,7 +791,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Named pattern is not needed."
-                        , details = [ "You should remove it at the location I pointed at." ]
+                        , details = redundantReplaceDetails
                         , under = "Singular _"
                         }
                         |> Review.Test.whenFixed
@@ -801,7 +805,7 @@ foo =
 """
                     , Review.Test.error
                         { message = "Named pattern is not needed."
-                        , details = [ "You should remove it at the location I pointed at." ]
+                        , details = redundantReplaceDetails
                         , under = "Pair _ _"
                         }
                         |> Review.Test.whenFixed
@@ -970,7 +974,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Tuple pattern is not needed."
-                        , details = [ "You should remove it at the location I pointed at." ]
+                        , details = redundantReplaceDetails
                         , under = "( _, _ )"
                         }
                         |> Review.Test.whenFixed
@@ -999,7 +1003,7 @@ foo =
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Tuple pattern is not needed."
-                        , details = [ "You should remove it at the location I pointed at." ]
+                        , details = redundantReplaceDetails
                         , under = "( _, _, _ )"
                         }
                         |> Review.Test.whenFixed


### PR DESCRIPTION
The current error details are confusing and misleading; they recommend "removing" patterns when the recommended fix is to replace them with `_`.

Fixes #22.