### PR TITLE
Variables: Avoid false positive around type name confusion

### DIFF
--- a/tests/NoUnused/VariablesTest.elm
+++ b/tests/NoUnused/VariablesTest.elm
@@ -1469,6 +1469,25 @@ shadowed = 1""" |> String.replace "$" " ")
                         ]
                       )
                     ]
+    , test "should not report imported type as unused when it's used in a type annotation, and the name conflicts with an imported custom type constructor" <|
+        \() ->
+            [ """module Main exposing (thing, main)
+import ModuleA exposing (A)
+import ModuleB exposing (Variants(..))
+
+thing : Variants
+thing = A
+
+main : A
+main = ()
+"""
+            , """module ModuleA exposing (A)
+type alias A = ()"""
+            , """module ModuleB exposing (Variants(..))
+type Variants = A"""
+            ]
+                |> Review.Test.runOnModules rule
+                |> Review.Test.expectNoErrors
     ]
 
 


### PR DESCRIPTION
Fixes #29
Avoids a false positive between imported types and imported
custom type constructors.

If someone would like to try it out:
```bash
elm-review --template jfmengels/elm-review-unused/preview#issue-15
```