### PR TITLE
Autofix removing unused constructors

### DIFF
--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -201,6 +201,7 @@ type alias ModuleContext =
     , constructorsToIgnore : List (Set ( ModuleName, String ))
     , locationsThatNeedsItself : Dict ( ModuleNameAsString, ConstructorName ) (List Range)
     , wasUsedInComparisons : Set ( ModuleNameAsString, ConstructorName )
+    , fixesForRemovingConstructor : Dict ( ModuleNameAsString, ConstructorName ) (List Range)
     , ignoredComparisonRanges : List Range
     }
 
@@ -239,6 +240,7 @@ fromProjectToModule lookupTable metadata projectContext =
     , constructorsToIgnore = []
     , locationsThatNeedsItself = Dict.empty
     , wasUsedInComparisons = Set.empty
+    , fixesForRemovingConstructor = Dict.empty
     , ignoredComparisonRanges = []
     }
 
@@ -703,7 +705,7 @@ expressionVisitorHelp node moduleContext =
             ( []
             , { moduleContext
                 | ignoreBlocks = newCases :: moduleContext.ignoreBlocks
-                , locationsThatNeedsItself =
+                , fixesForRemovingConstructor =
                     List.foldl
                         (\( nodeRange, constructor ) acc ->
                             Dict.update
@@ -711,7 +713,7 @@ expressionVisitorHelp node moduleContext =
                                 (Maybe.withDefault [] >> (\list -> Just (nodeRange :: list)))
                                 acc
                         )
-                        moduleContext.locationsThatNeedsItself
+                        moduleContext.fixesForRemovingConstructor
                         constructorsAndRangesToRemove
               }
             )

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -486,7 +486,7 @@ declarationVisitor node context =
                                     constructorInformation =
                                         { name = constructorName
                                         , rangeToReport = Node.range nameNode
-                                        , rangeToRemove = findRangeToRemove prev constructor next |> Debug.log "range to remove"
+                                        , rangeToRemove = findRangeToRemove prev constructor next
                                         }
                                 in
                                 ( Just constructor

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -788,13 +788,13 @@ finalProjectEvaluation projectContext =
                                 |> Dict.filter (\constructorName _ -> not <| Set.member constructorName usedConstructors)
                                 |> Dict.values
                                 |> List.map
-                                    (\{ name, rangeToReport } ->
+                                    (\constructorInformation ->
                                         errorForModule
                                             moduleKey
-                                            { wasUsedInLocationThatNeedsItself = Set.member ( moduleName, name ) projectContext.wasUsedInLocationThatNeedsItself
-                                            , wasUsedInComparisons = Set.member ( moduleName, name ) projectContext.wasUsedInComparisons
+                                            { wasUsedInLocationThatNeedsItself = Set.member ( moduleName, constructorInformation.name ) projectContext.wasUsedInLocationThatNeedsItself
+                                            , wasUsedInComparisons = Set.member ( moduleName, constructorInformation.name ) projectContext.wasUsedInComparisons
                                             }
-                                            (Node rangeToReport name)
+                                            constructorInformation
                                     )
                         )
             )
@@ -822,12 +822,12 @@ defaultDetails =
     "This type constructor is never used. It might be handled everywhere it might appear, but there is no location where this value actually gets created."
 
 
-errorForModule : Rule.ModuleKey -> { wasUsedInLocationThatNeedsItself : Bool, wasUsedInComparisons : Bool } -> Node String -> Error scope
-errorForModule moduleKey conditions node =
+errorForModule : Rule.ModuleKey -> { wasUsedInLocationThatNeedsItself : Bool, wasUsedInComparisons : Bool } -> ConstructorInformation -> Error scope
+errorForModule moduleKey conditions constructorInformation =
     Rule.errorForModule
         moduleKey
-        (errorInformation conditions (Node.value node))
-        (Node.range node)
+        (errorInformation conditions constructorInformation.name)
+        constructorInformation.rangeToReport
 
 
 

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -466,7 +466,7 @@ declarationVisitor node context =
                     constructorsForCustomType : Dict String ConstructorInformation
                     constructorsForCustomType =
                         List.foldl
-                            (\( index, constructor ) dict ->
+                            (\( index, constructor ) ( prev, dict ) ->
                                 let
                                     nameNode : Node String
                                     nameNode =
@@ -480,16 +480,19 @@ declarationVisitor node context =
                                     constructorInformation =
                                         { name = constructorName
                                         , rangeToReport = Node.range nameNode
-                                        , rangeToRemove = findRangeToRemove Nothing constructor Nothing nameNode
+                                        , rangeToRemove = findRangeToRemove prev constructor Nothing nameNode
                                         }
                                 in
-                                Dict.insert
+                                ( Just constructor
+                                , Dict.insert
                                     constructorName
                                     constructorInformation
                                     dict
+                                )
                             )
-                            Dict.empty
+                            ( Nothing, Dict.empty )
                             (List.indexedMap Tuple.pair constructors)
+                            |> Tuple.second
                 in
                 ( []
                 , { context

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -464,7 +464,7 @@ declarationVisitor node context =
                     constructorsForCustomType : Dict String ConstructorInformation
                     constructorsForCustomType =
                         List.foldl
-                            (\constructor dict ->
+                            (\( index, constructor ) dict ->
                                 let
                                     nameNode : Node String
                                     nameNode =
@@ -486,7 +486,7 @@ declarationVisitor node context =
                                     dict
                             )
                             Dict.empty
-                            constructors
+                            (List.indexedMap Tuple.pair constructors)
                 in
                 ( []
                 , { context

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -172,6 +172,7 @@ type ExposedConstructors
 type alias ConstructorInformation =
     { name : String
     , rangeToReport : Range
+    , rangeToRemove : Range
     }
 
 
@@ -478,6 +479,12 @@ declarationVisitor node context =
                                     constructorInformation =
                                         { name = constructorName
                                         , rangeToReport = Node.range nameNode
+
+                                        -- TODO Check that we don't remove it if there is only a single constructor
+                                        , rangeToRemove =
+                                            { start = (Node.range nameNode).start
+                                            , end = (Node.range constructor).end
+                                            }
                                         }
                                 in
                                 Dict.insert

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -677,10 +677,10 @@ expressionVisitorHelp node moduleContext =
                     replacement : String
                     replacement =
                         if operator == "==" then
-                            "True"
+                            "False"
 
                         else
-                            "False"
+                            "True"
 
                     ( fromThisModule, fromOtherModules ) =
                         constructors

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -824,10 +824,11 @@ defaultDetails =
 
 errorForModule : Rule.ModuleKey -> { wasUsedInLocationThatNeedsItself : Bool, wasUsedInComparisons : Bool } -> ConstructorInformation -> Error scope
 errorForModule moduleKey conditions constructorInformation =
-    Rule.errorForModule
+    Rule.errorForModuleWithFix
         moduleKey
         (errorInformation conditions constructorInformation.name)
         constructorInformation.rangeToReport
+        []
 
 
 

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -182,7 +182,7 @@ type alias ProjectContext =
     , declaredConstructors : Dict ModuleNameAsString ExposedConstructors
     , usedConstructors : Dict ModuleNameAsString (Set ConstructorName)
     , phantomVariables : Dict ModuleName (List ( CustomTypeName, Int ))
-    , wasUsedInLocationThatNeedsItself : Set ( ModuleNameAsString, ConstructorName )
+    , locationsThatNeedsItself : Set ( ModuleNameAsString, ConstructorName )
     , wasUsedInComparisons : Set ( ModuleNameAsString, ConstructorName )
     , wasUsedInOtherModules : Set ( ModuleNameAsString, ConstructorName )
     }
@@ -219,7 +219,7 @@ initialProjectContext phantomTypes =
             )
             Dict.empty
             phantomTypes
-    , wasUsedInLocationThatNeedsItself = Set.empty
+    , locationsThatNeedsItself = Set.empty
     , wasUsedInComparisons = Set.empty
     , wasUsedInOtherModules = Set.empty
     }
@@ -296,7 +296,7 @@ fromModuleToProject moduleKey metadata moduleContext =
             |> Dict.remove ""
             |> Dict.insert moduleNameAsString localUsed
     , phantomVariables = Dict.singleton moduleName localPhantomTypes
-    , wasUsedInLocationThatNeedsItself =
+    , locationsThatNeedsItself =
         Set.map
             (\(( moduleName_, constructorName ) as untouched) ->
                 if moduleName_ == "" then
@@ -341,7 +341,7 @@ foldProjectContexts newContext previousContext =
             previousContext.usedConstructors
             Dict.empty
     , phantomVariables = Dict.union newContext.phantomVariables previousContext.phantomVariables
-    , wasUsedInLocationThatNeedsItself = Set.union newContext.wasUsedInLocationThatNeedsItself previousContext.wasUsedInLocationThatNeedsItself
+    , locationsThatNeedsItself = Set.union newContext.locationsThatNeedsItself previousContext.locationsThatNeedsItself
     , wasUsedInComparisons = Set.union newContext.wasUsedInComparisons previousContext.wasUsedInComparisons
     , wasUsedInOtherModules = Set.union newContext.wasUsedInOtherModules previousContext.wasUsedInOtherModules
     }
@@ -829,7 +829,7 @@ finalProjectEvaluation projectContext =
                                     (\constructorInformation ->
                                         errorForModule
                                             moduleKey
-                                            { wasUsedInLocationThatNeedsItself = Set.member ( moduleName, constructorInformation.name ) projectContext.wasUsedInLocationThatNeedsItself
+                                            { wasUsedInLocationThatNeedsItself = Set.member ( moduleName, constructorInformation.name ) projectContext.locationsThatNeedsItself
                                             , wasUsedInComparisons = Set.member ( moduleName, constructorInformation.name ) projectContext.wasUsedInComparisons
                                             , isUsedInOtherModules = Set.member ( moduleName, constructorInformation.name ) projectContext.wasUsedInOtherModules
                                             }

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -173,7 +173,7 @@ type ExposedConstructors
 type alias ConstructorInformation =
     { name : String
     , rangeToReport : Range
-    , rangeToRemove : Range
+    , rangeToRemove : Maybe Range
     }
 
 
@@ -483,9 +483,10 @@ declarationVisitor node context =
 
                                         -- TODO Check that we don't remove it if there is only a single constructor
                                         , rangeToRemove =
-                                            { start = (Node.range nameNode).start
-                                            , end = (Node.range constructor).end
-                                            }
+                                            Just
+                                                { start = (Node.range nameNode).start
+                                                , end = (Node.range constructor).end
+                                                }
                                         }
                                 in
                                 Dict.insert
@@ -829,7 +830,13 @@ errorForModule moduleKey conditions constructorInformation =
         moduleKey
         (errorInformation conditions constructorInformation.name)
         constructorInformation.rangeToReport
-        [ Fix.removeRange constructorInformation.rangeToRemove ]
+        (case constructorInformation.rangeToRemove of
+            Just rangeToRemove ->
+                [ Fix.removeRange rangeToRemove ]
+
+            Nothing ->
+                []
+        )
 
 
 

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -463,10 +463,16 @@ declarationVisitor node context =
 
             else
                 let
+                    constructorsAndNext : List ( Maybe (Node Type.ValueConstructor), Node Type.ValueConstructor )
+                    constructorsAndNext =
+                        List.map2 Tuple.pair
+                            (Nothing :: List.map Just constructors)
+                            constructors
+
                     constructorsForCustomType : Dict String ConstructorInformation
                     constructorsForCustomType =
                         List.foldl
-                            (\( index, constructor ) ( prev, dict ) ->
+                            (\( next, constructor ) ( prev, dict ) ->
                                 let
                                     nameNode : Node String
                                     nameNode =
@@ -480,7 +486,7 @@ declarationVisitor node context =
                                     constructorInformation =
                                         { name = constructorName
                                         , rangeToReport = Node.range nameNode
-                                        , rangeToRemove = findRangeToRemove prev constructor Nothing nameNode
+                                        , rangeToRemove = findRangeToRemove prev constructor next nameNode
                                         }
                                 in
                                 ( Just constructor
@@ -491,7 +497,7 @@ declarationVisitor node context =
                                 )
                             )
                             ( Nothing, Dict.empty )
-                            (List.indexedMap Tuple.pair constructors)
+                            constructorsAndNext
                             |> Tuple.second
                 in
                 ( []

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -328,6 +328,7 @@ fromModuleToProject moduleKey metadata moduleContext =
                     acc
             )
             Set.empty
+            -- TODO add test to make sure we don't fix something that is pattern matched in other modules
             (Dict.toList <| Dict.remove "" moduleContext.usedFunctionsOrValues)
     , fixesForRemovingConstructor =
         mapDictKeys

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -203,6 +203,7 @@ type alias ModuleContext =
     , wasUsedInLocationThatNeedsItself : Set ( ModuleNameAsString, ConstructorName )
     , wasUsedInComparisons : Set ( ModuleNameAsString, ConstructorName )
     , fixesForRemovingConstructor : Dict ConstructorName (List Fix)
+    , wasUsedInOtherModules : Set ( ModuleNameAsString, ConstructorName )
     , ignoredComparisonRanges : List Range
     }
 
@@ -242,6 +243,7 @@ fromProjectToModule lookupTable metadata projectContext =
     , constructorsToIgnore = []
     , wasUsedInLocationThatNeedsItself = Set.empty
     , wasUsedInComparisons = Set.empty
+    , wasUsedInOtherModules = Set.empty
     , fixesForRemovingConstructor = Dict.empty
     , ignoredComparisonRanges = []
     }
@@ -327,7 +329,7 @@ fromModuleToProject moduleKey metadata moduleContext =
                     (Set.map (Tuple.pair moduleName_) constructors)
                     acc
             )
-            Set.empty
+            moduleContext.wasUsedInOtherModules
             -- TODO add test to make sure we don't fix something that is pattern matched in other modules
             (Dict.toList <| Dict.remove "" moduleContext.usedFunctionsOrValues)
     , fixesForRemovingConstructor =

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -691,7 +691,10 @@ expressionVisitorHelp node moduleContext =
                         |> RangeDict.fromList
             in
             ( []
-            , { moduleContext | ignoreBlocks = newCases :: moduleContext.ignoreBlocks }
+            , { moduleContext
+                | ignoreBlocks = newCases :: moduleContext.ignoreBlocks
+                , locationsThatNeedsItself = moduleContext.locationsThatNeedsItself
+              }
             )
 
         _ ->

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -23,6 +23,7 @@ import Elm.Syntax.Range exposing (Range)
 import Elm.Syntax.Type as Type
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (TypeAnnotation)
 import NoUnused.RangeDict as RangeDict exposing (RangeDict)
+import Review.Fix as Fix
 import Review.ModuleNameLookupTable as ModuleNameLookupTable exposing (ModuleNameLookupTable)
 import Review.Rule as Rule exposing (Error, Rule)
 import Set exposing (Set)
@@ -828,7 +829,7 @@ errorForModule moduleKey conditions constructorInformation =
         moduleKey
         (errorInformation conditions constructorInformation.name)
         constructorInformation.rangeToReport
-        []
+        [ Fix.removeRange constructorInformation.rangeToRemove ]
 
 
 

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -358,15 +358,19 @@ foldProjectContexts newContext previousContext =
     , wasUsedInLocationThatNeedsItself = Set.union newContext.wasUsedInLocationThatNeedsItself previousContext.wasUsedInLocationThatNeedsItself
     , wasUsedInComparisons = Set.union newContext.wasUsedInComparisons previousContext.wasUsedInComparisons
     , wasUsedInOtherModules = Set.union newContext.wasUsedInOtherModules previousContext.wasUsedInOtherModules
-    , fixesForRemovingConstructor =
-        Dict.merge
-            (\key a dict -> Dict.insert key a dict)
-            (\key a b dict -> Dict.insert key (a ++ b) dict)
-            (\key b dict -> Dict.insert key b dict)
-            newContext.fixesForRemovingConstructor
-            previousContext.fixesForRemovingConstructor
-            Dict.empty
+    , fixesForRemovingConstructor = mergeDictsWithLists newContext.fixesForRemovingConstructor previousContext.fixesForRemovingConstructor
     }
+
+
+mergeDictsWithLists : Dict comparable appendable -> Dict comparable appendable -> Dict comparable appendable
+mergeDictsWithLists left right =
+    Dict.merge
+        (\key a dict -> Dict.insert key a dict)
+        (\key a b dict -> Dict.insert key (a ++ b) dict)
+        (\key b dict -> Dict.insert key b dict)
+        left
+        right
+        Dict.empty
 
 
 

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -819,7 +819,7 @@ finalProjectEvaluation projectContext =
                                             moduleKey
                                             { wasUsedInLocationThatNeedsItself = Set.member ( moduleName, constructorInformation.name ) projectContext.wasUsedInLocationThatNeedsItself
                                             , wasUsedInComparisons = Set.member ( moduleName, constructorInformation.name ) projectContext.wasUsedInComparisons
-                                            , isExposed = True
+                                            , isUsedInOtherModules = True
                                             }
                                             constructorInformation
                                     )
@@ -849,7 +849,7 @@ defaultDetails =
     "This type constructor is never used. It might be handled everywhere it might appear, but there is no location where this value actually gets created."
 
 
-errorForModule : Rule.ModuleKey -> { wasUsedInLocationThatNeedsItself : Bool, wasUsedInComparisons : Bool, isExposed : Bool } -> ConstructorInformation -> Error scope
+errorForModule : Rule.ModuleKey -> { wasUsedInLocationThatNeedsItself : Bool, wasUsedInComparisons : Bool, isUsedInOtherModules : Bool } -> ConstructorInformation -> Error scope
 errorForModule moduleKey conditions constructorInformation =
     Rule.errorForModuleWithFix
         moduleKey
@@ -857,7 +857,7 @@ errorForModule moduleKey conditions constructorInformation =
         constructorInformation.rangeToReport
         (case constructorInformation.rangeToRemove of
             Just rangeToRemove ->
-                if conditions.isExposed then
+                if conditions.isUsedInOtherModules then
                     []
 
                 else

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -690,13 +690,13 @@ expressionVisitorHelp node moduleContext =
                         |> List.map (Tuple.mapFirst .bodyRange)
                         |> RangeDict.fromList
 
-                constructorsAndRangesToRemove : List ( { bodyRange : Range, nodeRange : Range }, ( ModuleNameAsString, ConstructorName ) )
+                constructorsAndRangesToRemove : List ( Range, ( ModuleNameAsString, ConstructorName ) )
                 constructorsAndRangesToRemove =
                     List.concatMap
                         (\( ranges, constructors ) ->
                             constructors
                                 |> Set.toList
-                                |> List.map (\( moduleName, constructorName ) -> ( ranges, ( String.join "." moduleName, constructorName ) ))
+                                |> List.map (\( moduleName, constructorName ) -> ( ranges.nodeRange, ( String.join "." moduleName, constructorName ) ))
                         )
                         casesAndConstructors
             in
@@ -705,7 +705,7 @@ expressionVisitorHelp node moduleContext =
                 | ignoreBlocks = newCases :: moduleContext.ignoreBlocks
                 , locationsThatNeedsItself =
                     List.foldl
-                        (\( { nodeRange }, constructor ) acc ->
+                        (\( nodeRange, constructor ) acc ->
                             Dict.update
                                 constructor
                                 (Maybe.withDefault [] >> (\list -> Just (nodeRange :: list)))

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -466,7 +466,7 @@ declarationVisitor node context =
                     constructorsAndNext : List ( Maybe (Node Type.ValueConstructor), Node Type.ValueConstructor )
                     constructorsAndNext =
                         List.map2 Tuple.pair
-                            (Nothing :: List.map Just constructors)
+                            (List.map Just (List.drop 1 constructors) ++ [ Nothing ])
                             constructors
 
                     constructorsForCustomType : Dict String ConstructorInformation

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -887,6 +887,7 @@ finalProjectEvaluation projectContext =
                                                     |> Maybe.withDefault []
                                             , wasUsedInComparisons = Set.member ( moduleName, constructorInformation.name ) projectContext.wasUsedInComparisons
                                             , isUsedInOtherModules = Set.member ( moduleName, constructorInformation.name ) projectContext.wasUsedInOtherModules
+                                            , fixesForRemovingConstructor = Dict.get ( moduleName, constructorInformation.name ) projectContext.fixesForRemovingConstructor |> Maybe.withDefault []
                                             }
                                             constructorInformation
                                     )
@@ -916,7 +917,16 @@ defaultDetails =
     "This type constructor is never used. It might be handled everywhere it might appear, but there is no location where this value actually gets created."
 
 
-errorForModule : Rule.ModuleKey -> { locationsWhereItUsedItself : List Range, wasUsedInComparisons : Bool, isUsedInOtherModules : Bool } -> ConstructorInformation -> Error scope
+errorForModule :
+    Rule.ModuleKey
+    ->
+        { locationsWhereItUsedItself : List Range
+        , wasUsedInComparisons : Bool
+        , isUsedInOtherModules : Bool
+        , fixesForRemovingConstructor : List Fix
+        }
+    -> ConstructorInformation
+    -> Error scope
 errorForModule moduleKey params constructorInformation =
     Rule.errorForModuleWithFix
         moduleKey
@@ -933,7 +943,7 @@ errorForModule moduleKey params constructorInformation =
                     []
 
                 else
-                    Fix.removeRange rangeToRemove :: List.map Fix.removeRange params.locationsWhereItUsedItself
+                    Fix.removeRange rangeToRemove :: params.fixesForRemovingConstructor
 
             Nothing ->
                 []

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -480,13 +480,7 @@ declarationVisitor node context =
                                     constructorInformation =
                                         { name = constructorName
                                         , rangeToReport = Node.range nameNode
-
-                                        -- TODO Check that we don't remove it if there is only a single constructor
-                                        , rangeToRemove =
-                                            Just
-                                                { start = (Node.range nameNode).start
-                                                , end = (Node.range constructor).end
-                                                }
+                                        , rangeToRemove = findRangeToRemove index constructor nameNode
                                         }
                                 in
                                 Dict.insert
@@ -519,6 +513,14 @@ declarationVisitor node context =
 
         _ ->
             ( [], context )
+
+
+findRangeToRemove index constructor nameNode =
+    -- TODO Check that we don't remove it if there is only a single constructor
+    Just
+        { start = (Node.range nameNode).start
+        , end = (Node.range constructor).end
+        }
 
 
 isPhantomCustomType : Node String -> List (Node Type.ValueConstructor) -> Bool

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -199,7 +199,7 @@ type alias ModuleContext =
     , phantomVariables : Dict ModuleName (List ( CustomTypeName, Int ))
     , ignoreBlocks : List (RangeDict (Set ( ModuleName, String )))
     , constructorsToIgnore : List (Set ( ModuleName, String ))
-    , wasUsedInLocationThatNeedsItself : Set ( ModuleNameAsString, ConstructorName )
+    , locationsThatNeedsItself : Set ( ModuleNameAsString, ConstructorName )
     , wasUsedInComparisons : Set ( ModuleNameAsString, ConstructorName )
     , ignoredComparisonRanges : List Range
     }
@@ -237,7 +237,7 @@ fromProjectToModule lookupTable metadata projectContext =
     , phantomVariables = projectContext.phantomVariables
     , ignoreBlocks = []
     , constructorsToIgnore = []
-    , wasUsedInLocationThatNeedsItself = Set.empty
+    , locationsThatNeedsItself = Set.empty
     , wasUsedInComparisons = Set.empty
     , ignoredComparisonRanges = []
     }
@@ -305,7 +305,7 @@ fromModuleToProject moduleKey metadata moduleContext =
                 else
                     untouched
             )
-            moduleContext.wasUsedInLocationThatNeedsItself
+            moduleContext.locationsThatNeedsItself
     , wasUsedInComparisons =
         Set.map
             (\(( moduleName_, constructorName ) as untouched) ->
@@ -777,10 +777,10 @@ registerUsedFunctionOrValue range moduleName name moduleContext =
 
     else if List.any (Set.member ( moduleName, name )) moduleContext.constructorsToIgnore then
         { moduleContext
-            | wasUsedInLocationThatNeedsItself =
+            | locationsThatNeedsItself =
                 Set.insert
                     ( String.join "." moduleName, name )
-                    moduleContext.wasUsedInLocationThatNeedsItself
+                    moduleContext.locationsThatNeedsItself
         }
 
     else

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -23,7 +23,7 @@ import Elm.Syntax.Range exposing (Range)
 import Elm.Syntax.Type as Type
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (TypeAnnotation)
 import NoUnused.RangeDict as RangeDict exposing (RangeDict)
-import Review.Fix as Fix
+import Review.Fix as Fix exposing (Fix)
 import Review.ModuleNameLookupTable as ModuleNameLookupTable exposing (ModuleNameLookupTable)
 import Review.Rule as Rule exposing (Error, Rule)
 import Set exposing (Set)
@@ -185,7 +185,7 @@ type alias ProjectContext =
     , locationsThatNeedsItself : Dict ( ModuleNameAsString, ConstructorName ) (List Range)
     , wasUsedInComparisons : Set ( ModuleNameAsString, ConstructorName )
     , wasUsedInOtherModules : Set ( ModuleNameAsString, ConstructorName )
-    , fixesForRemovingConstructor : Dict ( ModuleNameAsString, ConstructorName ) (List Range)
+    , fixesForRemovingConstructor : Dict ( ModuleNameAsString, ConstructorName ) (List Fix)
     }
 
 
@@ -202,7 +202,7 @@ type alias ModuleContext =
     , constructorsToIgnore : List (Set ( ModuleName, String ))
     , locationsThatNeedsItself : Dict ( ModuleNameAsString, ConstructorName ) (List Range)
     , wasUsedInComparisons : Set ( ModuleNameAsString, ConstructorName )
-    , fixesForRemovingConstructor : Dict ( ModuleNameAsString, ConstructorName ) (List Range)
+    , fixesForRemovingConstructor : Dict ( ModuleNameAsString, ConstructorName ) (List Fix)
     , ignoredComparisonRanges : List Range
     }
 
@@ -723,7 +723,7 @@ expressionVisitorHelp node moduleContext =
                         (\( nodeRange, constructor ) acc ->
                             Dict.update
                                 constructor
-                                (Maybe.withDefault [] >> (\list -> Just (nodeRange :: list)))
+                                (Maybe.withDefault [] >> (\list -> Just (Fix.removeRange nodeRange :: list)))
                                 acc
                         )
                         moduleContext.fixesForRemovingConstructor

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -480,7 +480,7 @@ declarationVisitor node context =
                                     constructorInformation =
                                         { name = constructorName
                                         , rangeToReport = Node.range nameNode
-                                        , rangeToRemove = findRangeToRemove index constructor nameNode
+                                        , rangeToRemove = findRangeToRemove Nothing constructor Nothing nameNode
                                         }
                                 in
                                 Dict.insert
@@ -515,12 +515,25 @@ declarationVisitor node context =
             ( [], context )
 
 
-findRangeToRemove index constructor nameNode =
-    -- TODO Check that we don't remove it if there is only a single constructor
-    Just
-        { start = (Node.range nameNode).start
-        , end = (Node.range constructor).end
-        }
+findRangeToRemove : Maybe (Node a) -> Node b -> Maybe (Node c) -> Node d -> Maybe { start : Elm.Syntax.Range.Location, end : Elm.Syntax.Range.Location }
+findRangeToRemove previousConstructor constructor nextConstructor nameNode =
+    case previousConstructor of
+        Just prev ->
+            Just
+                { start = (Node.range prev).end
+                , end = (Node.range constructor).end
+                }
+
+        Nothing ->
+            case nextConstructor of
+                Just next ->
+                    Just
+                        { start = (Node.range nameNode).start
+                        , end = (Node.range next).start
+                        }
+
+                Nothing ->
+                    Nothing
 
 
 isPhantomCustomType : Node String -> List (Node Type.ValueConstructor) -> Bool

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -669,10 +669,19 @@ expressionVisitorHelp node moduleContext =
 
         Expression.CaseExpression { cases } ->
             let
-                casesAndConstructors : List ( { bodyRange : Range }, Set ( ModuleName, String ) )
+                casesAndConstructors : List ( { bodyRange : Range, nodeRange : Range }, Set ( ModuleName, String ) )
                 casesAndConstructors =
                     List.map
-                        (\( pattern, body ) -> ( { bodyRange = Node.range body }, constructorsInPattern moduleContext.lookupTable pattern ))
+                        (\( pattern, body ) ->
+                            ( { bodyRange = Node.range body
+                              , nodeRange =
+                                    { start = (Node.range pattern).start
+                                    , end = (Node.range body).end
+                                    }
+                              }
+                            , constructorsInPattern moduleContext.lookupTable pattern
+                            )
+                        )
                         cases
 
                 newCases : RangeDict (Set ( ModuleName, String ))

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -358,7 +358,14 @@ foldProjectContexts newContext previousContext =
     , wasUsedInLocationThatNeedsItself = Set.union newContext.wasUsedInLocationThatNeedsItself previousContext.wasUsedInLocationThatNeedsItself
     , wasUsedInComparisons = Set.union newContext.wasUsedInComparisons previousContext.wasUsedInComparisons
     , wasUsedInOtherModules = Set.union newContext.wasUsedInOtherModules previousContext.wasUsedInOtherModules
-    , fixesForRemovingConstructor = Dict.union newContext.fixesForRemovingConstructor previousContext.fixesForRemovingConstructor
+    , fixesForRemovingConstructor =
+        Dict.merge
+            (\key a dict -> Dict.insert key a dict)
+            (\key a b dict -> Dict.insert key (a ++ b) dict)
+            (\key b dict -> Dict.insert key b dict)
+            newContext.fixesForRemovingConstructor
+            previousContext.fixesForRemovingConstructor
+            Dict.empty
     }
 
 

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -819,6 +819,7 @@ finalProjectEvaluation projectContext =
                                             moduleKey
                                             { wasUsedInLocationThatNeedsItself = Set.member ( moduleName, constructorInformation.name ) projectContext.wasUsedInLocationThatNeedsItself
                                             , wasUsedInComparisons = Set.member ( moduleName, constructorInformation.name ) projectContext.wasUsedInComparisons
+                                            , isExposed = True
                                             }
                                             constructorInformation
                                     )
@@ -830,7 +831,7 @@ finalProjectEvaluation projectContext =
 -- ERROR
 
 
-errorInformation : { wasUsedInLocationThatNeedsItself : Bool, wasUsedInComparisons : Bool } -> String -> { message : String, details : List String }
+errorInformation : { a | wasUsedInLocationThatNeedsItself : Bool, wasUsedInComparisons : Bool } -> String -> { message : String, details : List String }
 errorInformation { wasUsedInLocationThatNeedsItself, wasUsedInComparisons } name =
     { message = "Type constructor `" ++ name ++ "` is not used."
     , details =
@@ -848,7 +849,7 @@ defaultDetails =
     "This type constructor is never used. It might be handled everywhere it might appear, but there is no location where this value actually gets created."
 
 
-errorForModule : Rule.ModuleKey -> { wasUsedInLocationThatNeedsItself : Bool, wasUsedInComparisons : Bool } -> ConstructorInformation -> Error scope
+errorForModule : Rule.ModuleKey -> { wasUsedInLocationThatNeedsItself : Bool, wasUsedInComparisons : Bool, isExposed : Bool } -> ConstructorInformation -> Error scope
 errorForModule moduleKey conditions constructorInformation =
     Rule.errorForModuleWithFix
         moduleKey
@@ -856,7 +857,11 @@ errorForModule moduleKey conditions constructorInformation =
         constructorInformation.rangeToReport
         (case constructorInformation.rangeToRemove of
             Just rangeToRemove ->
-                [ Fix.removeRange rangeToRemove ]
+                if conditions.isExposed then
+                    []
+
+                else
+                    [ Fix.removeRange rangeToRemove ]
 
             Nothing ->
                 []

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -185,6 +185,7 @@ type alias ProjectContext =
     , locationsThatNeedsItself : Dict ( ModuleNameAsString, ConstructorName ) (List Range)
     , wasUsedInComparisons : Set ( ModuleNameAsString, ConstructorName )
     , wasUsedInOtherModules : Set ( ModuleNameAsString, ConstructorName )
+    , fixesForRemovingConstructor : Dict ( ModuleNameAsString, ConstructorName ) (List Range)
     }
 
 
@@ -223,6 +224,7 @@ initialProjectContext phantomTypes =
     , locationsThatNeedsItself = Dict.empty
     , wasUsedInComparisons = Set.empty
     , wasUsedInOtherModules = Set.empty
+    , fixesForRemovingConstructor = Dict.empty
     }
 
 
@@ -327,6 +329,16 @@ fromModuleToProject moduleKey metadata moduleContext =
             )
             Set.empty
             (Dict.toList <| Dict.remove "" moduleContext.usedFunctionsOrValues)
+    , fixesForRemovingConstructor =
+        mapDictKeys
+            (\(( moduleName_, constructorName ) as untouched) ->
+                if moduleName_ == "" then
+                    ( moduleNameAsString, constructorName )
+
+                else
+                    untouched
+            )
+            moduleContext.fixesForRemovingConstructor
     }
 
 
@@ -346,6 +358,7 @@ foldProjectContexts newContext previousContext =
     , locationsThatNeedsItself = Dict.union newContext.locationsThatNeedsItself previousContext.locationsThatNeedsItself
     , wasUsedInComparisons = Set.union newContext.wasUsedInComparisons previousContext.wasUsedInComparisons
     , wasUsedInOtherModules = Set.union newContext.wasUsedInOtherModules previousContext.wasUsedInOtherModules
+    , fixesForRemovingConstructor = Dict.union newContext.fixesForRemovingConstructor previousContext.fixesForRemovingConstructor
     }
 
 

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -669,10 +669,16 @@ expressionVisitorHelp node moduleContext =
 
         Expression.CaseExpression { cases } ->
             let
+                casesAndConstructors : List ( { bodyRange : Range }, Set ( ModuleName, String ) )
+                casesAndConstructors =
+                    List.map
+                        (\( pattern, body ) -> ( { bodyRange = Node.range body }, constructorsInPattern moduleContext.lookupTable pattern ))
+                        cases
+
                 newCases : RangeDict (Set ( ModuleName, String ))
                 newCases =
-                    cases
-                        |> List.map (\( pattern, body ) -> ( Node.range body, constructorsInPattern moduleContext.lookupTable pattern ))
+                    casesAndConstructors
+                        |> List.map (Tuple.mapFirst .bodyRange)
                         |> RangeDict.fromList
             in
             ( []

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -324,7 +324,7 @@ fromModuleToProject moduleKey metadata moduleContext =
                     acc
             )
             Set.empty
-            (Dict.toList moduleContext.usedFunctionsOrValues)
+            (Dict.toList <| Dict.remove "" moduleContext.usedFunctionsOrValues)
     }
 
 

--- a/src/NoUnused/CustomTypeConstructors.elm
+++ b/src/NoUnused/CustomTypeConstructors.elm
@@ -486,7 +486,7 @@ declarationVisitor node context =
                                     constructorInformation =
                                         { name = constructorName
                                         , rangeToReport = Node.range nameNode
-                                        , rangeToRemove = findRangeToRemove prev constructor next nameNode
+                                        , rangeToRemove = findRangeToRemove prev constructor next |> Debug.log "range to remove"
                                         }
                                 in
                                 ( Just constructor
@@ -524,8 +524,8 @@ declarationVisitor node context =
             ( [], context )
 
 
-findRangeToRemove : Maybe (Node a) -> Node b -> Maybe (Node c) -> Node d -> Maybe { start : Elm.Syntax.Range.Location, end : Elm.Syntax.Range.Location }
-findRangeToRemove previousConstructor constructor nextConstructor nameNode =
+findRangeToRemove : Maybe (Node a) -> Node Type.ValueConstructor -> Maybe (Node c) -> Maybe { start : Elm.Syntax.Range.Location, end : Elm.Syntax.Range.Location }
+findRangeToRemove previousConstructor constructor nextConstructor =
     case previousConstructor of
         Just prev ->
             Just
@@ -537,7 +537,7 @@ findRangeToRemove previousConstructor constructor nextConstructor nameNode =
             case nextConstructor of
                 Just next ->
                     Just
-                        { start = (Node.range nameNode).start
+                        { start = constructor |> Node.value |> .name |> Node.range |> .start
                         , end = (Node.range next).start
                         }
 

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -197,12 +197,13 @@ a = case () of
                                 }
                                 |> Review.Test.atExactly { start = { row = 3, column = 19 }, end = { row = 3, column = 25 } }
                                 |> Review.Test.whenFixed
-                                    """
+                                    ("""
 module MyModule exposing (a)
 type Foo = Used
 a = case () of
+       $
         Used -> Used
-"""
+""" |> String.replace "$" " ")
                             ]
         , test "should report type constructors that are only used inside deep pattern matches that require themselves" <|
             \() ->

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -196,6 +196,13 @@ a = case () of
                                 , under = "Unused"
                                 }
                                 |> Review.Test.atExactly { start = { row = 3, column = 19 }, end = { row = 3, column = 25 } }
+                                |> Review.Test.whenFixed
+                                    """
+module MyModule exposing (a)
+type Foo = Used
+a = case () of
+        Used -> Used
+"""
                             ]
         , test "should report type constructors that are only used inside deep pattern matches that require themselves" <|
             \() ->

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -204,6 +204,31 @@ a = case () of
         Used -> Used
 """ |> String.replace "$" " ")
                         ]
+        , test "should report type constructors that are only used inside pattern matches that require themselves (reversed order of patterns)" <|
+            \() ->
+                """
+module MyModule exposing (a)
+type Foo = Used | Unused
+a = case () of
+        Used -> Used
+        Unused -> Unused + Used
+"""
+                    |> Review.Test.runWithProjectData project (rule [])
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Type constructor `Unused` is not used."
+                            , details = [ defaultDetails, recursiveNeedDetails ]
+                            , under = "Unused"
+                            }
+                            |> Review.Test.atExactly { start = { row = 3, column = 19 }, end = { row = 3, column = 25 } }
+                            |> Review.Test.whenFixed
+                                ("""
+module MyModule exposing (a)
+type Foo = Used
+a = case () of
+        Used -> Used
+""" |> String.replace "$" " ")
+                        ]
         , test "should report type constructors that are only used inside deep pattern matches that require themselves" <|
             \() ->
                 """

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -693,25 +693,26 @@ type Foo = Bar | Baz
                             , under = "Baz"
                             }
                         ]
-        , test "should report unused type constructors when application module is exposing the constructors" <|
-            \() ->
-                """
+        , Test.only <|
+            test "should report unused type constructors when application module is exposing the constructors" <|
+                \() ->
+                    """
 module MyModule exposing (Foo(..))
 type Foo = Bar | Baz
 """
-                    |> Review.Test.runWithProjectData applicationProject (rule [])
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Type constructor `Bar` is not used."
-                            , details = [ defaultDetails ]
-                            , under = "Bar"
-                            }
-                        , Review.Test.error
-                            { message = "Type constructor `Baz` is not used."
-                            , details = [ defaultDetails ]
-                            , under = "Baz"
-                            }
-                        ]
+                        |> Review.Test.runWithProjectData applicationProject (rule [])
+                        |> Review.Test.expectErrors
+                            [ Review.Test.error
+                                { message = "Type constructor `Bar` is not used."
+                                , details = [ defaultDetails ]
+                                , under = "Bar"
+                                }
+                            , Review.Test.error
+                                { message = "Type constructor `Baz` is not used."
+                                , details = [ defaultDetails ]
+                                , under = "Baz"
+                                }
+                            ]
         ]
 
 

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -178,33 +178,32 @@ type Foo = Baz"""
 module MyModule exposing (Foo)
 type Foo = Bar"""
                         ]
-        , Test.only <|
-            test "should report type constructors that are only used inside pattern matches that require themselves" <|
-                \() ->
-                    """
+        , test "should report type constructors that are only used inside pattern matches that require themselves" <|
+            \() ->
+                """
 module MyModule exposing (a)
 type Foo = Used | Unused
 a = case () of
         Unused -> Unused + Used
         Used -> Used
 """
-                        |> Review.Test.runWithProjectData project (rule [])
-                        |> Review.Test.expectErrors
-                            [ Review.Test.error
-                                { message = "Type constructor `Unused` is not used."
-                                , details = [ defaultDetails, recursiveNeedDetails ]
-                                , under = "Unused"
-                                }
-                                |> Review.Test.atExactly { start = { row = 3, column = 19 }, end = { row = 3, column = 25 } }
-                                |> Review.Test.whenFixed
-                                    ("""
+                    |> Review.Test.runWithProjectData project (rule [])
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Type constructor `Unused` is not used."
+                            , details = [ defaultDetails, recursiveNeedDetails ]
+                            , under = "Unused"
+                            }
+                            |> Review.Test.atExactly { start = { row = 3, column = 19 }, end = { row = 3, column = 25 } }
+                            |> Review.Test.whenFixed
+                                ("""
 module MyModule exposing (a)
 type Foo = Used
 a = case () of
        $
         Used -> Used
 """ |> String.replace "$" " ")
-                            ]
+                        ]
         , test "should report type constructors that are only used inside deep pattern matches that require themselves" <|
             \() ->
                 """

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -272,6 +272,13 @@ b = B
                             , under = "Unused"
                             }
                             |> Review.Test.atExactly { start = { row = 3, column = 12 }, end = { row = 3, column = 18 } }
+                            |> Review.Test.whenFixed
+                                """
+module MyModule exposing (a, b)
+type Foo = B
+a = True
+b = B
+"""
                         ]
         , test "should not count type constructors used in an equality expression (/=)" <|
             \() ->
@@ -289,6 +296,13 @@ b = B
                             , under = "Unused"
                             }
                             |> Review.Test.atExactly { start = { row = 3, column = 12 }, end = { row = 3, column = 18 } }
+                            |> Review.Test.whenFixed
+                                """
+module MyModule exposing (a, b)
+type Foo = B
+a = False
+b = B
+"""
                         ]
         , test "should count type constructors used in a function call inside an equality expression" <|
             \() ->

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -138,11 +138,19 @@ type Foo = Bar | Baz"""
                             , details = [ defaultDetails ]
                             , under = "Bar"
                             }
+                            |> Review.Test.whenFixed
+                                """
+module MyModule exposing (b)
+type Foo = Baz"""
                         , Review.Test.error
                             { message = "Type constructor `Baz` is not used."
                             , details = [ defaultDetails ]
                             , under = "Baz"
                             }
+                            |> Review.Test.whenFixed
+                                """
+module MyModule exposing (b)
+type Foo = Bar"""
                         ]
         , test "should report unused type constructors, even if the type is exposed" <|
             \() ->
@@ -345,11 +353,29 @@ id = Id
                             , details = [ defaultDetails ]
                             , under = "A"
                             }
+                            |> Review.Test.whenFixed
+                                """
+module MyModule exposing (id)
+type Something = B
+type Id a = Id
+
+id : Id Something
+id = Id
+"""
                         , Review.Test.error
                             { message = "Type constructor `B` is not used."
                             , details = [ defaultDetails ]
                             , under = "B"
                             }
+                            |> Review.Test.whenFixed
+                                """
+module MyModule exposing (id)
+type Something = A
+type Id a = Id
+
+id : Id Something
+id = Id
+"""
                         ]
         , test "should report a custom type with one constructor, when there is a phantom type available but it isn't used" <|
             \() ->
@@ -473,11 +499,29 @@ id = Id
                             , under = "User"
                             }
                             |> Review.Test.atExactly { start = { row = 3, column = 13 }, end = { row = 3, column = 17 } }
+                            |> Review.Test.whenFixed
+                                """
+module MyModule exposing (id)
+type User = Other
+type Id a = Id a
+
+id : Id User
+id = Id
+"""
                         , Review.Test.error
                             { message = "Type constructor `Other` is not used."
                             , details = [ defaultDetails ]
                             , under = "Other"
                             }
+                            |> Review.Test.whenFixed
+                                """
+module MyModule exposing (id)
+type User = User Never
+type Id a = Id a
+
+id : Id User
+id = Id
+"""
                         ]
         , test "should not report a phantom type if it is used in another module (directly imported)" <|
             \() ->
@@ -609,11 +653,21 @@ type Foo = Bar | Baz
                             , details = [ defaultDetails ]
                             , under = "Bar"
                             }
+                            |> Review.Test.whenFixed
+                                """
+module MyModule exposing (..)
+type Foo = Baz
+"""
                         , Review.Test.error
                             { message = "Type constructor `Baz` is not used."
                             , details = [ defaultDetails ]
                             , under = "Baz"
                             }
+                            |> Review.Test.whenFixed
+                                """
+module MyModule exposing (..)
+type Foo = Bar
+"""
                         ]
         , test "should report unused type constructors when a package module is exposing all and module is exposed but types are not" <|
             \() ->
@@ -660,11 +714,21 @@ type Foo = Bar | Baz
                             , details = [ defaultDetails ]
                             , under = "Bar"
                             }
+                            |> Review.Test.whenFixed
+                                """
+module MyModule exposing (..)
+type Foo = Baz
+"""
                         , Review.Test.error
                             { message = "Type constructor `Baz` is not used."
                             , details = [ defaultDetails ]
                             , under = "Baz"
                             }
+                            |> Review.Test.whenFixed
+                                """
+module MyModule exposing (..)
+type Foo = Bar
+"""
                         ]
         , test "should not report unused type constructors when package module is exposing the constructors of that type and module is exposed" <|
             \() ->
@@ -687,11 +751,21 @@ type Foo = Bar | Baz
                             , details = [ defaultDetails ]
                             , under = "Bar"
                             }
+                            |> Review.Test.whenFixed
+                                """
+module MyModule exposing (Foo(..))
+type Foo = Baz
+"""
                         , Review.Test.error
                             { message = "Type constructor `Baz` is not used."
                             , details = [ defaultDetails ]
                             , under = "Baz"
                             }
+                            |> Review.Test.whenFixed
+                                """
+module MyModule exposing (Foo(..))
+type Foo = Bar
+"""
                         ]
         , test "should report unused type constructors when application module is exposing the constructors" <|
             \() ->

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -694,26 +694,25 @@ type Foo = Bar | Baz
                             , under = "Baz"
                             }
                         ]
-        , Test.only <|
-            test "should report unused type constructors when application module is exposing the constructors" <|
-                \() ->
-                    """
+        , test "should report unused type constructors when application module is exposing the constructors" <|
+            \() ->
+                """
 module MyModule exposing (Foo(..))
 type Foo = Bar | Baz
 """
-                        |> Review.Test.runWithProjectData applicationProject (rule [])
-                        |> Review.Test.expectErrors
-                            [ Review.Test.error
-                                { message = "Type constructor `Bar` is not used."
-                                , details = [ defaultDetails ]
-                                , under = "Bar"
-                                }
-                            , Review.Test.error
-                                { message = "Type constructor `Baz` is not used."
-                                , details = [ defaultDetails ]
-                                , under = "Baz"
-                                }
-                            ]
+                    |> Review.Test.runWithProjectData applicationProject (rule [])
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Type constructor `Bar` is not used."
+                            , details = [ defaultDetails ]
+                            , under = "Bar"
+                            }
+                        , Review.Test.error
+                            { message = "Type constructor `Baz` is not used."
+                            , details = [ defaultDetails ]
+                            , under = "Baz"
+                            }
+                        ]
         ]
 
 

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -933,6 +933,27 @@ type Msg = NoOp
                             ]
                           )
                         ]
+        , test "should report but not fix if constructor is handled in a pattern" <|
+            \() ->
+                [ """module A exposing (main)
+import Other exposing (Msg(..))
+a = Used
+main = case foo of
+  Unused -> 1
+""", """module Other exposing (Msg(..))
+type Msg = Unused | Used
+""" ]
+                    |> Review.Test.runOnModulesWithProjectData project (rule [])
+                    |> Review.Test.expectErrorsForModules
+                        [ ( "Other"
+                          , [ Review.Test.error
+                                { message = "Type constructor `Unused` is not used."
+                                , details = [ defaultDetails ]
+                                , under = "Unused"
+                                }
+                            ]
+                          )
+                        ]
         , test "should not report type constructors in confusing situations" <|
             \() ->
                 [ """module A exposing (A(..))

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -144,33 +144,32 @@ type Foo = Bar | Baz"""
                             , under = "Baz"
                             }
                         ]
-        , Test.only <|
-            test "should report unused type constructors, even if the type is exposed" <|
-                \() ->
-                    """
+        , test "should report unused type constructors, even if the type is exposed" <|
+            \() ->
+                """
 module MyModule exposing (Foo)
 type Foo = Bar | Baz"""
-                        |> Review.Test.runWithProjectData project (rule [])
-                        |> Review.Test.expectErrors
-                            [ Review.Test.error
-                                { message = "Type constructor `Bar` is not used."
-                                , details = [ defaultDetails ]
-                                , under = "Bar"
-                                }
-                                |> Review.Test.whenFixed
-                                    """
+                    |> Review.Test.runWithProjectData project (rule [])
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Type constructor `Bar` is not used."
+                            , details = [ defaultDetails ]
+                            , under = "Bar"
+                            }
+                            |> Review.Test.whenFixed
+                                """
 module MyModule exposing (Foo)
 type Foo = Baz"""
-                            , Review.Test.error
-                                { message = "Type constructor `Baz` is not used."
-                                , details = [ defaultDetails ]
-                                , under = "Baz"
-                                }
-                                |> Review.Test.whenFixed
-                                    """
+                        , Review.Test.error
+                            { message = "Type constructor `Baz` is not used."
+                            , details = [ defaultDetails ]
+                            , under = "Baz"
+                            }
+                            |> Review.Test.whenFixed
+                                """
 module MyModule exposing (Foo)
 type Foo = Bar"""
-                            ]
+                        ]
         , test "should report type constructors that are only used inside pattern matches that require themselves" <|
             \() ->
                 """

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -204,24 +204,33 @@ a = case () of
         Used -> Used
 """ |> String.replace "$" " ")
                         ]
-        , test "should report type constructors that are only used inside deep pattern matches that require themselves" <|
-            \() ->
-                """
+        , Test.only <|
+            test "should report type constructors that are only used inside deep pattern matches that require themselves" <|
+                \() ->
+                    """
 module MyModule exposing (a)
 type Foo = Used | Unused
 a = case () of
         Foo (a :: [ ( Unused as b, bar ) ]) -> Unused + Used
         Used -> Used
 """
-                    |> Review.Test.runWithProjectData project (rule [])
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Type constructor `Unused` is not used."
-                            , details = [ defaultDetails, recursiveNeedDetails ]
-                            , under = "Unused"
-                            }
-                            |> Review.Test.atExactly { start = { row = 3, column = 19 }, end = { row = 3, column = 25 } }
-                        ]
+                        |> Review.Test.runWithProjectData project (rule [])
+                        |> Review.Test.expectErrors
+                            [ Review.Test.error
+                                { message = "Type constructor `Unused` is not used."
+                                , details = [ defaultDetails, recursiveNeedDetails ]
+                                , under = "Unused"
+                                }
+                                |> Review.Test.atExactly { start = { row = 3, column = 19 }, end = { row = 3, column = 25 } }
+                                |> Review.Test.whenFixed
+                                    ("""
+module MyModule exposing (a)
+type Foo = Used
+a = case () of
+       $
+        Used -> Used
+""" |> String.replace "$" " ")
+                            ]
         , test "should properly remove the ignored constructors once the pattern has been left" <|
             \() ->
                 """

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -301,7 +301,7 @@ b = B
                                 """
 module MyModule exposing (a, b)
 type Foo = B
-a = True
+a = False
 b = B
 """
                         ]
@@ -325,7 +325,7 @@ b = B
                                 """
 module MyModule exposing (a, b)
 type Foo = B
-a = False
+a = True
 b = B
 """
                         ]
@@ -359,7 +359,7 @@ b = B
                                 """
 module MyModule exposing (a, b)
 type Foo = B
-a = False
+a = True
 b = B
 """
                         ]

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -178,24 +178,25 @@ type Foo = Baz"""
 module MyModule exposing (Foo)
 type Foo = Bar"""
                         ]
-        , test "should report type constructors that are only used inside pattern matches that require themselves" <|
-            \() ->
-                """
+        , Test.only <|
+            test "should report type constructors that are only used inside pattern matches that require themselves" <|
+                \() ->
+                    """
 module MyModule exposing (a)
 type Foo = Used | Unused
 a = case () of
         Unused -> Unused + Used
         Used -> Used
 """
-                    |> Review.Test.runWithProjectData project (rule [])
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Type constructor `Unused` is not used."
-                            , details = [ defaultDetails, recursiveNeedDetails ]
-                            , under = "Unused"
-                            }
-                            |> Review.Test.atExactly { start = { row = 3, column = 19 }, end = { row = 3, column = 25 } }
-                        ]
+                        |> Review.Test.runWithProjectData project (rule [])
+                        |> Review.Test.expectErrors
+                            [ Review.Test.error
+                                { message = "Type constructor `Unused` is not used."
+                                , details = [ defaultDetails, recursiveNeedDetails ]
+                                , under = "Unused"
+                                }
+                                |> Review.Test.atExactly { start = { row = 3, column = 19 }, end = { row = 3, column = 25 } }
+                            ]
         , test "should report type constructors that are only used inside deep pattern matches that require themselves" <|
             \() ->
                 """

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -126,24 +126,25 @@ a = Bar
 b = Baz"""
                     |> Review.Test.runWithProjectData project (rule [])
                     |> Review.Test.expectNoErrors
-        , test "should report unused type constructors" <|
-            \() ->
-                """
+        , Test.only <|
+            test "should report unused type constructors" <|
+                \() ->
+                    """
 module MyModule exposing (b)
 type Foo = Bar | Baz"""
-                    |> Review.Test.runWithProjectData project (rule [])
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Type constructor `Bar` is not used."
-                            , details = [ defaultDetails ]
-                            , under = "Bar"
-                            }
-                        , Review.Test.error
-                            { message = "Type constructor `Baz` is not used."
-                            , details = [ defaultDetails ]
-                            , under = "Baz"
-                            }
-                        ]
+                        |> Review.Test.runWithProjectData project (rule [])
+                        |> Review.Test.expectErrors
+                            [ Review.Test.error
+                                { message = "Type constructor `Bar` is not used."
+                                , details = [ defaultDetails ]
+                                , under = "Bar"
+                                }
+                            , Review.Test.error
+                                { message = "Type constructor `Baz` is not used."
+                                , details = [ defaultDetails ]
+                                , under = "Baz"
+                                }
+                            ]
         , test "should report unused type constructors, even if the type is exposed" <|
             \() ->
                 """

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -330,6 +330,13 @@ b = B
                             , under = "Unused"
                             }
                             |> Review.Test.atExactly { start = { row = 3, column = 12 }, end = { row = 3, column = 18 } }
+                            |> Review.Test.whenFixed
+                                """
+module MyModule exposing (a, b)
+type Foo = B
+a = False
+b = B
+"""
                         ]
         ]
 

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -204,33 +204,32 @@ a = case () of
         Used -> Used
 """ |> String.replace "$" " ")
                         ]
-        , Test.only <|
-            test "should report type constructors that are only used inside deep pattern matches that require themselves" <|
-                \() ->
-                    """
+        , test "should report type constructors that are only used inside deep pattern matches that require themselves" <|
+            \() ->
+                """
 module MyModule exposing (a)
 type Foo = Used | Unused
 a = case () of
         Foo (a :: [ ( Unused as b, bar ) ]) -> Unused + Used
         Used -> Used
 """
-                        |> Review.Test.runWithProjectData project (rule [])
-                        |> Review.Test.expectErrors
-                            [ Review.Test.error
-                                { message = "Type constructor `Unused` is not used."
-                                , details = [ defaultDetails, recursiveNeedDetails ]
-                                , under = "Unused"
-                                }
-                                |> Review.Test.atExactly { start = { row = 3, column = 19 }, end = { row = 3, column = 25 } }
-                                |> Review.Test.whenFixed
-                                    ("""
+                    |> Review.Test.runWithProjectData project (rule [])
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Type constructor `Unused` is not used."
+                            , details = [ defaultDetails, recursiveNeedDetails ]
+                            , under = "Unused"
+                            }
+                            |> Review.Test.atExactly { start = { row = 3, column = 19 }, end = { row = 3, column = 25 } }
+                            |> Review.Test.whenFixed
+                                ("""
 module MyModule exposing (a)
 type Foo = Used
 a = case () of
        $
         Used -> Used
 """ |> String.replace "$" " ")
-                            ]
+                        ]
         , test "should properly remove the ignored constructors once the pattern has been left" <|
             \() ->
                 """

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -126,25 +126,24 @@ a = Bar
 b = Baz"""
                     |> Review.Test.runWithProjectData project (rule [])
                     |> Review.Test.expectNoErrors
-        , Test.only <|
-            test "should report unused type constructors" <|
-                \() ->
-                    """
+        , test "should report unused type constructors" <|
+            \() ->
+                """
 module MyModule exposing (b)
 type Foo = Bar | Baz"""
-                        |> Review.Test.runWithProjectData project (rule [])
-                        |> Review.Test.expectErrors
-                            [ Review.Test.error
-                                { message = "Type constructor `Bar` is not used."
-                                , details = [ defaultDetails ]
-                                , under = "Bar"
-                                }
-                            , Review.Test.error
-                                { message = "Type constructor `Baz` is not used."
-                                , details = [ defaultDetails ]
-                                , under = "Baz"
-                                }
-                            ]
+                    |> Review.Test.runWithProjectData project (rule [])
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Type constructor `Bar` is not used."
+                            , details = [ defaultDetails ]
+                            , under = "Bar"
+                            }
+                        , Review.Test.error
+                            { message = "Type constructor `Baz` is not used."
+                            , details = [ defaultDetails ]
+                            , under = "Baz"
+                            }
+                        ]
         , test "should report unused type constructors, even if the type is exposed" <|
             \() ->
                 """
@@ -694,25 +693,26 @@ type Foo = Bar | Baz
                             , under = "Baz"
                             }
                         ]
-        , test "should report unused type constructors when application module is exposing the constructors" <|
-            \() ->
-                """
+        , Test.only <|
+            test "should report unused type constructors when application module is exposing the constructors" <|
+                \() ->
+                    """
 module MyModule exposing (Foo(..))
 type Foo = Bar | Baz
 """
-                    |> Review.Test.runWithProjectData applicationProject (rule [])
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Type constructor `Bar` is not used."
-                            , details = [ defaultDetails ]
-                            , under = "Bar"
-                            }
-                        , Review.Test.error
-                            { message = "Type constructor `Baz` is not used."
-                            , details = [ defaultDetails ]
-                            , under = "Baz"
-                            }
-                        ]
+                        |> Review.Test.runWithProjectData applicationProject (rule [])
+                        |> Review.Test.expectErrors
+                            [ Review.Test.error
+                                { message = "Type constructor `Bar` is not used."
+                                , details = [ defaultDetails ]
+                                , under = "Bar"
+                                }
+                            , Review.Test.error
+                                { message = "Type constructor `Baz` is not used."
+                                , details = [ defaultDetails ]
+                                , under = "Baz"
+                                }
+                            ]
         ]
 
 

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -693,36 +693,35 @@ type Foo = Bar | Baz
                             , under = "Baz"
                             }
                         ]
-        , Test.only <|
-            test "should report unused type constructors when application module is exposing the constructors" <|
-                \() ->
-                    """
+        , test "should report unused type constructors when application module is exposing the constructors" <|
+            \() ->
+                """
 module MyModule exposing (Foo(..))
 type Foo = Bar | Baz
 """
-                        |> Review.Test.runWithProjectData applicationProject (rule [])
-                        |> Review.Test.expectErrors
-                            [ Review.Test.error
-                                { message = "Type constructor `Bar` is not used."
-                                , details = [ defaultDetails ]
-                                , under = "Bar"
-                                }
-                                |> Review.Test.whenFixed
-                                    """
+                    |> Review.Test.runWithProjectData applicationProject (rule [])
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Type constructor `Bar` is not used."
+                            , details = [ defaultDetails ]
+                            , under = "Bar"
+                            }
+                            |> Review.Test.whenFixed
+                                """
 module MyModule exposing (Foo(..))
 type Foo = Baz
 """
-                            , Review.Test.error
-                                { message = "Type constructor `Baz` is not used."
-                                , details = [ defaultDetails ]
-                                , under = "Baz"
-                                }
-                                |> Review.Test.whenFixed
-                                    """
+                        , Review.Test.error
+                            { message = "Type constructor `Baz` is not used."
+                            , details = [ defaultDetails ]
+                            , under = "Baz"
+                            }
+                            |> Review.Test.whenFixed
+                                """
 module MyModule exposing (Foo(..))
 type Foo = Bar
 """
-                            ]
+                        ]
         ]
 
 

--- a/tests/NoUnused/CustomTypeConstructorsTest.elm
+++ b/tests/NoUnused/CustomTypeConstructorsTest.elm
@@ -707,11 +707,21 @@ type Foo = Bar | Baz
                                 , details = [ defaultDetails ]
                                 , under = "Bar"
                                 }
+                                |> Review.Test.whenFixed
+                                    """
+module MyModule exposing (Foo(..))
+type Foo = Baz
+"""
                             , Review.Test.error
                                 { message = "Type constructor `Baz` is not used."
                                 , details = [ defaultDetails ]
                                 , under = "Baz"
                                 }
+                                |> Review.Test.whenFixed
+                                    """
+module MyModule exposing (Foo(..))
+type Foo = Bar
+"""
                             ]
         ]
 


### PR DESCRIPTION
Propose a fix for removing unused constructors in the `NoUnused.CustomTypeConstructors` rule.

This is only done when the constructor is only used or referenced in the file it was defined in, because `elm-review` doesn't allow multi-file fixes.

What this autofix does:
- Remove the constructor from the custom type
- Remove any pattern match referencing the constructor
- Turn any comparison with expressions referencing the constructor to a boolean
  - `False` for expressions like `if thing == Unused`
  - `True` for expressions like `if thing /= Unused`

![Screenshot from 2021-04-10 12-09-48](https://user-images.githubusercontent.com/3869412/114266272-afc6a300-99f5-11eb-8406-f452911cbfbd.png)


## Testing

I would like people to test this one out, since there's a higher chance than usual that I messed things up and that it leads to a compiler error.
I'd love it if people could try this one out, and see whether it causes any code to stop compiling or behaving differently.

```bash
npx elm-review --template jfmengels/elm-review-unused/preview#remove-unused-constructor --rules NoUnused.CustomTypeConstructors --fix
```