### PR TITLE
NoUnused.Exports: Don't report types used in port declarations

### DIFF
--- a/src/NoUnused/Exports.elm
+++ b/src/NoUnused/Exports.elm
@@ -572,8 +572,8 @@ typesUsedInDeclaration moduleContext declaration =
         Declaration.AliasDeclaration alias_ ->
             ( collectTypesFromTypeAnnotation moduleContext alias_.typeAnnotation, False )
 
-        Declaration.PortDeclaration _ ->
-            ( [], False )
+        Declaration.PortDeclaration signature ->
+            ( collectTypesFromTypeAnnotation moduleContext signature.typeAnnotation, False )
 
         Declaration.InfixDeclaration _ ->
             ( [], False )

--- a/tests/NoUnused/ExportsTest.elm
+++ b/tests/NoUnused/ExportsTest.elm
@@ -517,6 +517,28 @@ type Type1 = Type1
 """ ]
                     |> Review.Test.runOnModulesWithProjectData application rule
                     |> Review.Test.expectNoErrors
+        , test "should not report an exposed type if it is used in a port (input)" <|
+            \() ->
+                [ """module Main exposing (main)
+import B
+main = somePort
+port somePort : (B.Type1 -> msg) -> Sub msg
+""", """module B exposing (Type1)
+type alias Type1 = { user : String }
+""" ]
+                    |> Review.Test.runOnModulesWithProjectData application rule
+                    |> Review.Test.expectNoErrors
+        , test "should not report an exposed type if it is used in a port (output)" <|
+            \() ->
+                [ """module Main exposing (main)
+import B
+main = somePort
+port somePort : B.Type1 -> Cmd msg
+""", """module B exposing (Type1)
+type alias Type1 = { user : String }
+""" ]
+                    |> Review.Test.runOnModulesWithProjectData application rule
+                    |> Review.Test.expectNoErrors
         ]
 
 


### PR DESCRIPTION
Fixes https://github.com/jfmengels/review-unused/issues/25