### PR TITLE
Fixes #42: False positive in aliased custom type

### DIFF
--- a/src/NoUnused/Variables.elm
+++ b/src/NoUnused/Variables.elm
@@ -955,26 +955,31 @@ declarationListVisitor nodes context =
                       }
                     )
 
-                Declaration.AliasDeclaration { name, documentation } ->
+                Declaration.AliasDeclaration { name, documentation, typeAnnotation } ->
                     let
                         contextWithRemovedShadowedImports : ModuleContext
                         contextWithRemovedShadowedImports =
                             { ctx | importedCustomTypeLookup = Dict.remove (Node.value name) ctx.importedCustomTypeLookup }
                     in
-                    ( []
-                    , if ctx.exposesEverything then
-                        contextWithRemovedShadowedImports
+                    case Node.value typeAnnotation of
+                        TypeAnnotation.Record _ ->
+                            ( []
+                            , if ctx.exposesEverything then
+                                contextWithRemovedShadowedImports
 
-                      else
-                        registerVariable
-                            { typeName = "Type"
-                            , under = Node.range name
-                            , rangeToRemove = Just (rangeToRemoveForNodeWithDocumentation node documentation)
-                            , warning = ""
-                            }
-                            (Node.value name)
-                            contextWithRemovedShadowedImports
-                    )
+                              else
+                                registerVariable
+                                    { typeName = "Type"
+                                    , under = Node.range name
+                                    , rangeToRemove = Just (rangeToRemoveForNodeWithDocumentation node documentation)
+                                    , warning = ""
+                                    }
+                                    (Node.value name)
+                                    contextWithRemovedShadowedImports
+                            )
+
+                        _ ->
+                            ( [], ctx )
 
                 _ ->
                     ( errors, ctx )

--- a/tests/NoUnused/VariablesTest.elm
+++ b/tests/NoUnused/VariablesTest.elm
@@ -914,7 +914,7 @@ type C = C_Value
             ]
                 |> Review.Test.runOnModules rule
                 |> Review.Test.expectNoErrors
-    , test "should report open type import when the exposed constructor is shadowed by a local type alias" <|
+    , test "should report open type import when the exposed constructor is shadowed by a local type alias when it is a record" <|
         \() ->
             [ """module A exposing (a)
 import B exposing (C(..))
@@ -939,6 +939,18 @@ a = C_Value""" |> String.replace "$" " ")
                         ]
                       )
                     ]
+    , test "should not report open type import when the exposed constructor is shadowed by a local type alias when it is not a record" <|
+        \() ->
+            [ """module A exposing (a)
+import B exposing (C(..))
+type alias C = B.C
+a = C"""
+            , """module B exposing (C(..))
+type C = C
+"""
+            ]
+                |> Review.Test.runOnModules rule
+                |> Review.Test.expectNoErrors
     , test "should report open type import when the exposed constructor even when there is a following type alias import" <|
         \() ->
             [ """module A exposing (a)


### PR DESCRIPTION
The bug is basically that the code assumed that a type alias declaration creates a function with that name that would shadow any imported definition with that same name.

However, this is only the case when you declare a record type alias. Other type aliases do not affect the value level namespace at all.