### PR TITLE
Fixes type aliases not being reported when they don't alias a record

### DIFF
--- a/src/NoUnused/Variables.elm
+++ b/src/NoUnused/Variables.elm
@@ -993,14 +993,18 @@ registerTypeAlias range { name, typeAnnotation } context =
                 typeAlias
                 contextWithRemovedShadowedImports.localCustomTypes
 
-        contextWithRemovedShadowedImports : ModuleContext
-        contextWithRemovedShadowedImports =
+        importedCustomTypeLookup : Dict String String
+        importedCustomTypeLookup =
             case Node.value typeAnnotation of
                 TypeAnnotation.Record _ ->
-                    { context | importedCustomTypeLookup = Dict.remove (Node.value name) context.importedCustomTypeLookup }
+                    Dict.remove (Node.value name) context.importedCustomTypeLookup
 
                 _ ->
-                    context
+                    context.importedCustomTypeLookup
+
+        contextWithRemovedShadowedImports : ModuleContext
+        contextWithRemovedShadowedImports =
+            { context | importedCustomTypeLookup = importedCustomTypeLookup }
 
         -- TODO Rename
         typeAlias : CustomTypeData

--- a/src/NoUnused/Variables.elm
+++ b/src/NoUnused/Variables.elm
@@ -1400,8 +1400,18 @@ finalEvaluation context =
 
 errorForLocalType : ( String, TypeData ) -> Error {}
 errorForLocalType ( name, type_ ) =
+    let
+        kind : String
+        kind =
+            case type_.kind of
+                CustomTypeKind ->
+                    "Type"
+
+                TypeAliasKind ->
+                    "Type alias"
+    in
     Rule.errorWithFix
-        { message = "Type `" ++ name ++ "` is not used"
+        { message = kind ++ " `" ++ name ++ "` is not used"
         , details = details
         }
         type_.under

--- a/src/NoUnused/Variables.elm
+++ b/src/NoUnused/Variables.elm
@@ -132,9 +132,15 @@ type alias DeclaredModule =
 
 type alias TypeData =
     { under : Range
+    , kind : TypeKind
     , rangeToRemove : Range
     , variants : List String
     }
+
+
+type TypeKind
+    = CustomTypeKind
+    | TypeAliasKind
 
 
 type alias ModuleThatExposesEverything =
@@ -1008,7 +1014,8 @@ registerTypeAlias range { name, typeAnnotation } context =
 
         typeAlias : TypeData
         typeAlias =
-            { under = Node.range name
+            { kind = TypeAliasKind
+            , under = Node.range name
             , rangeToRemove = untilStartOfNextLine range
             , variants =
                 case Node.value typeAnnotation of
@@ -1057,7 +1064,8 @@ registerCustomType range { name, constructors } context =
 
         customType : TypeData
         customType =
-            { under = Node.range name
+            { kind = CustomTypeKind
+            , under = Node.range name
             , rangeToRemove = untilStartOfNextLine range
             , variants = constructorNames
             }

--- a/src/NoUnused/Variables.elm
+++ b/src/NoUnused/Variables.elm
@@ -986,6 +986,13 @@ registerTypes node context =
 registerTypeAlias : Range -> TypeAlias -> ModuleContext -> ModuleContext
 registerTypeAlias range { name, typeAnnotation } context =
     let
+        localCustomTypes : Dict String CustomTypeData
+        localCustomTypes =
+            Dict.insert
+                (Node.value name)
+                typeAlias
+                contextWithRemovedShadowedImports.localCustomTypes
+
         contextWithRemovedShadowedImports : ModuleContext
         contextWithRemovedShadowedImports =
             case Node.value typeAnnotation of
@@ -996,6 +1003,12 @@ registerTypeAlias range { name, typeAnnotation } context =
                     context
 
         -- TODO Rename
+        typeAlias : CustomTypeData
+        typeAlias =
+            { under = Node.range name
+            , rangeToRemove = untilStartOfNextLine range
+            , variants = []
+            }
     in
     case Node.value typeAnnotation of
         TypeAnnotation.Record _ ->
@@ -1013,21 +1026,7 @@ registerTypeAlias range { name, typeAnnotation } context =
                     contextWithRemovedShadowedImports
 
         _ ->
-            let
-                typeAlias : CustomTypeData
-                typeAlias =
-                    { under = Node.range name
-                    , rangeToRemove = untilStartOfNextLine range
-                    , variants = []
-                    }
-            in
-            { contextWithRemovedShadowedImports
-                | localCustomTypes =
-                    Dict.insert
-                        (Node.value name)
-                        typeAlias
-                        contextWithRemovedShadowedImports.localCustomTypes
-            }
+            { contextWithRemovedShadowedImports | localCustomTypes = localCustomTypes }
 
 
 registerCustomType : Range -> Elm.Syntax.Type.Type -> ModuleContext -> ModuleContext

--- a/src/NoUnused/Variables.elm
+++ b/src/NoUnused/Variables.elm
@@ -1385,15 +1385,7 @@ finalEvaluation context =
                 context.localTypes
                     |> Dict.toList
                     |> List.filter (\( name, _ ) -> not <| Set.member name usedLocally)
-                    |> List.map
-                        (\( name, type_ ) ->
-                            Rule.errorWithFix
-                                { message = "Type `" ++ name ++ "` is not used"
-                                , details = details
-                                }
-                                type_.under
-                                [ Fix.removeRange type_.rangeToRemove ]
-                        )
+                    |> List.map errorForLocalType
     in
     List.concat
         [ newRootScope
@@ -1404,6 +1396,16 @@ finalEvaluation context =
         , List.filterMap Tuple.first moduleThatExposeEverythingErrors
         , customTypeErrors
         ]
+
+
+errorForLocalType : ( String, TypeData ) -> Error {}
+errorForLocalType ( name, type_ ) =
+    Rule.errorWithFix
+        { message = "Type `" ++ name ++ "` is not used"
+        , details = details
+        }
+        type_.under
+        [ Fix.removeRange type_.rangeToRemove ]
 
 
 registerFunction : LetBlockContext -> Function -> ModuleContext -> ModuleContext

--- a/src/NoUnused/Variables.elm
+++ b/src/NoUnused/Variables.elm
@@ -1386,13 +1386,13 @@ finalEvaluation context =
                     |> Dict.toList
                     |> List.filter (\( name, _ ) -> not <| Set.member name usedLocally)
                     |> List.map
-                        (\( name, customType ) ->
+                        (\( name, type_ ) ->
                             Rule.errorWithFix
                                 { message = "Type `" ++ name ++ "` is not used"
                                 , details = details
                                 }
-                                customType.under
-                                [ Fix.removeRange customType.rangeToRemove ]
+                                type_.under
+                                [ Fix.removeRange type_.rangeToRemove ]
                         )
     in
     List.concat

--- a/src/NoUnused/Variables.elm
+++ b/src/NoUnused/Variables.elm
@@ -1011,7 +1011,13 @@ registerTypeAlias range { name, typeAnnotation } context =
         typeAlias =
             { under = Node.range name
             , rangeToRemove = untilStartOfNextLine range
-            , variants = []
+            , variants =
+                case Node.value typeAnnotation of
+                    TypeAnnotation.Record _ ->
+                        [ Node.value name ]
+
+                    _ ->
+                        []
             }
     in
     case Node.value typeAnnotation of

--- a/src/NoUnused/Variables.elm
+++ b/src/NoUnused/Variables.elm
@@ -992,13 +992,6 @@ registerTypes node context =
 registerTypeAlias : Range -> TypeAlias -> ModuleContext -> ModuleContext
 registerTypeAlias range { name, typeAnnotation } context =
     let
-        localCustomTypes : Dict String TypeData
-        localCustomTypes =
-            Dict.insert
-                (Node.value name)
-                typeAlias
-                contextWithRemovedShadowedImports.localTypes
-
         importedCustomTypeLookup : Dict String String
         importedCustomTypeLookup =
             case Node.value typeAnnotation of
@@ -1011,20 +1004,6 @@ registerTypeAlias range { name, typeAnnotation } context =
         contextWithRemovedShadowedImports : ModuleContext
         contextWithRemovedShadowedImports =
             { context | importedCustomTypeLookup = importedCustomTypeLookup }
-
-        typeAlias : TypeData
-        typeAlias =
-            { kind = TypeAliasKind
-            , under = Node.range name
-            , rangeToRemove = untilStartOfNextLine range
-            , variants =
-                case Node.value typeAnnotation of
-                    TypeAnnotation.Record _ ->
-                        [ Node.value name ]
-
-                    _ ->
-                        []
-            }
     in
     case Node.value typeAnnotation of
         TypeAnnotation.Record _ ->
@@ -1042,6 +1021,28 @@ registerTypeAlias range { name, typeAnnotation } context =
                     contextWithRemovedShadowedImports
 
         _ ->
+            let
+                typeAlias : TypeData
+                typeAlias =
+                    { kind = TypeAliasKind
+                    , under = Node.range name
+                    , rangeToRemove = untilStartOfNextLine range
+                    , variants =
+                        case Node.value typeAnnotation of
+                            TypeAnnotation.Record _ ->
+                                [ Node.value name ]
+
+                            _ ->
+                                []
+                    }
+
+                localCustomTypes : Dict String TypeData
+                localCustomTypes =
+                    Dict.insert
+                        (Node.value name)
+                        typeAlias
+                        contextWithRemovedShadowedImports.localTypes
+            in
             { contextWithRemovedShadowedImports | localTypes = localCustomTypes }
 
 

--- a/tests/NoUnused/VariablesTest.elm
+++ b/tests/NoUnused/VariablesTest.elm
@@ -1006,7 +1006,7 @@ type C = C
                 |> Review.Test.expectErrorsForModules
                     [ ( "A"
                       , [ Review.Test.error
-                            { message = "Type `C` is not used"
+                            { message = "Type alias `C` is not used"
                             , details = details
                             , under = "C"
                             }
@@ -1057,10 +1057,10 @@ a = B
                         , under = "B"
                         }
                         |> Review.Test.atExactly { start = { row = 3, column = 12 }, end = { row = 3, column = 13 } }
-                        |> Review.Test.whenFixed ("""module A exposing (a)
-import B$
-type Type = C
-a = C""" |> String.replace "$" " ")
+                        |> Review.Test.whenFixed """module A exposing (a)
+type A = B | C
+a = B
+"""
                     ]
     , test "should not report open type import when a constructor is used but the type is locally shadowed" <|
         \() ->
@@ -2102,7 +2102,7 @@ a = 1
                 |> Review.Test.run rule
                 |> Review.Test.expectErrors
                     [ Review.Test.error
-                        { message = "Type `UnusedType` is not used"
+                        { message = "Type alias `UnusedType` is not used"
                         , details = details
                         , under = "UnusedType"
                         }

--- a/tests/NoUnused/VariablesTest.elm
+++ b/tests/NoUnused/VariablesTest.elm
@@ -1042,6 +1042,26 @@ a = C""" |> String.replace "$" " ")
                         ]
                       )
                     ]
+    , test "should report type alias that doesn't alias a record when it has the same name as a constructor defined in the same file" <|
+        \() ->
+            """module A exposing (a)
+type A = B | C
+type alias B = Int
+a = B
+"""
+                |> Review.Test.run rule
+                |> Review.Test.expectErrors
+                    [ Review.Test.error
+                        { message = "Type alias `B` is not used"
+                        , details = details
+                        , under = "B"
+                        }
+                        |> Review.Test.atExactly { start = { row = 3, column = 12 }, end = { row = 3, column = 13 } }
+                        |> Review.Test.whenFixed ("""module A exposing (a)
+import B$
+type Type = C
+a = C""" |> String.replace "$" " ")
+                    ]
     , test "should not report open type import when a constructor is used but the type is locally shadowed" <|
         \() ->
             [ """module A exposing (a)


### PR DESCRIPTION
Fixes #48 

@smucode Could you please check whether this works well for you? You can run the following:

```bash
elm-review --template jfmengels/elm-review-unused/preview#type-alias-through-constructor --rules NoUnused.Variables
```

(If need be, use `--ignore-dirs` or `--ignore-files`)