### PR TITLE
Make NoUnused.Patterns report unnecessary aliases

### DIFF
--- a/src/NoUnused/Parameters.elm
+++ b/src/NoUnused/Parameters.elm
@@ -120,7 +120,6 @@ type alias FunctionArgs =
 type Kind
     = Parameter
     | Alias
-    | AsWithoutVariables
     | TupleWithoutVariables
 
 
@@ -301,18 +300,7 @@ getParametersFromAsPattern source pattern asName =
             , source = source
             }
     in
-    if List.isEmpty parametersFromPatterns && isPatternWildCard pattern then
-        [ asParameter
-        , { name = ""
-          , range = Node.range pattern
-          , kind = AsWithoutVariables
-          , fix = [ Fix.removeRange { start = (Node.range pattern).start, end = (Node.range asName).start } ]
-          , source = source
-          }
-        ]
-
-    else
-        asParameter :: parametersFromPatterns
+    asParameter :: parametersFromPatterns
 
 
 isPatternWildCard : Node Pattern -> Bool
@@ -587,11 +575,6 @@ errorMessage kind name =
         Alias ->
             { message = "Pattern alias `" ++ name ++ "` is not used"
             , details = [ "You should either use this parameter somewhere, or remove it at the location I pointed at." ]
-            }
-
-        AsWithoutVariables ->
-            { message = "Pattern does not introduce any variables"
-            , details = [ "You should remove this pattern." ]
             }
 
         TupleWithoutVariables ->

--- a/src/NoUnused/Patterns.elm
+++ b/src/NoUnused/Patterns.elm
@@ -627,8 +627,11 @@ errorsForAsPattern patternRange inner (Node range name) context =
 
 
 findPatternForAsPattern : Range -> Node Pattern -> Node String -> FoundPattern
-findPatternForAsPattern patternRange inner (Node range name) =
+findPatternForAsPattern patternRange inner ((Node range name) as nameNode) =
     case Node.value inner of
+        Pattern.ParenthesizedPattern subPattern ->
+            findPatternForAsPattern patternRange subPattern nameNode
+
         Pattern.AllPattern ->
             SimplifiablePattern
                 (Rule.errorWithFix

--- a/src/NoUnused/Patterns.elm
+++ b/src/NoUnused/Patterns.elm
@@ -642,6 +642,15 @@ findPatternForAsPattern patternRange pattern ((Node range name) as nameNode) =
                     [ Fix.replaceRangeBy patternRange name ]
                 )
 
+        Pattern.VarPattern innerName ->
+            SimplifiablePattern
+                (Rule.error
+                    { message = "Unnecessary duplicate alias `" ++ name ++ "`"
+                    , details = [ "This alias is redundant because the value is already named `" ++ innerName ++ "`. I suggest you remove one of them." ]
+                    }
+                    range
+                )
+
         Pattern.AsPattern _ (Node innerRange innerName) ->
             SimplifiablePattern
                 (Rule.error

--- a/src/NoUnused/Patterns.elm
+++ b/src/NoUnused/Patterns.elm
@@ -628,32 +628,33 @@ errorsForAsPattern patternRange inner (Node range name) context =
 
 findPatternForAsPattern : Range -> Node Pattern -> Node String -> FoundPattern
 findPatternForAsPattern patternRange inner (Node range name) =
-    if isAllPattern inner then
-        SimplifiablePattern
-            (Rule.errorWithFix
-                { message = "Pattern `_` is not needed"
-                , details = removeDetails
-                }
-                (Node.range inner)
-                [ Fix.replaceRangeBy patternRange name ]
-            )
+    case Node.value inner of
+        Pattern.AllPattern ->
+            SimplifiablePattern
+                (Rule.errorWithFix
+                    { message = "Pattern `_` is not needed"
+                    , details = removeDetails
+                    }
+                    (Node.range inner)
+                    [ Fix.replaceRangeBy patternRange name ]
+                )
 
-    else
-        let
-            fix : List Fix
-            fix =
-                [ inner
-                    |> writePattern
-                    |> Fix.replaceRangeBy patternRange
-                ]
-        in
-        SingleValue
-            { name = name
-            , message = "Pattern alias `" ++ name ++ "` is not used"
-            , details = singularRemoveDetails
-            , range = range
-            , fix = fix
-            }
+        _ ->
+            let
+                fix : List Fix
+                fix =
+                    [ inner
+                        |> writePattern
+                        |> Fix.replaceRangeBy patternRange
+                    ]
+            in
+            SingleValue
+                { name = name
+                , message = "Pattern alias `" ++ name ++ "` is not used"
+                , details = singularRemoveDetails
+                , range = range
+                , fix = fix
+                }
 
 
 isAllPattern : Node Pattern -> Bool

--- a/tests/NoUnused/ParametersTest.elm
+++ b/tests/NoUnused/ParametersTest.elm
@@ -252,24 +252,15 @@ foo =
         bish
 """
                     ]
-    , test "should report unused patterns that are aliased" <|
+    , test "should not report aliases to wildcards" <|
+        -- Already handled by `NoUnused.Patterns`
         \() ->
             """module A exposing (..)
 foo =
     \\(_ as bar) -> bar
 """
                 |> Review.Test.run rule
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Pattern does not introduce any variables"
-                        , details = [ "You should remove this pattern." ]
-                        , under = "_"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
-foo =
-    \\(bar) -> bar
-"""
-                    ]
+                |> Review.Test.expectNoErrors
     , test "should report nested unused pattern aliases" <|
         \() ->
             """module A exposing (..)
@@ -547,20 +538,15 @@ foo ({ bish, bash } as bosh) =
                         , under = "bosh"
                         }
                     ]
-    , test "should report unused patterns that are aliased" <|
+    , test "should not report aliases to wildcards" <|
+        -- Already handled by `NoUnused.Patterns`
         \() ->
             """module A exposing (..)
 foo (_ as bar) =
     bar
 """
                 |> Review.Test.run rule
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Pattern does not introduce any variables"
-                        , details = [ "You should remove this pattern." ]
-                        , under = "_"
-                        }
-                    ]
+                |> Review.Test.expectNoErrors
     , test "should report nested unused pattern aliases" <|
         \() ->
             """module A exposing (..)

--- a/tests/NoUnused/PatternsTest.elm
+++ b/tests/NoUnused/PatternsTest.elm
@@ -651,6 +651,26 @@ foo =
             bosh
 """
                     ]
+    , test "should report duplicate aliases" <|
+        \() ->
+            """
+module A exposing (..)
+foo =
+    case maybeTupleMaybe of
+        Just ( ((Foo bash) as bosh) as bish ) ->
+            bash + bosh + bish
+        _ ->
+            0
+"""
+                |> Review.Test.run rule
+                |> Review.Test.expectErrors
+                    [ Review.Test.error
+                        { message = "Unnecessary duplicate alias `bosh`"
+                        , details = [ "This name is redundant because the value is already aliased as `bish`. I suggest you remove one of them." ]
+                        , under = "bosh"
+                        }
+                        |> Review.Test.atExactly { start = { row = 5, column = 31 }, end = { row = 5, column = 35 } }
+                    ]
     ]
 
 

--- a/tests/NoUnused/PatternsTest.elm
+++ b/tests/NoUnused/PatternsTest.elm
@@ -651,6 +651,26 @@ foo =
             bosh
 """
                     ]
+    , test "should report aliases to a name" <|
+        \() ->
+            """
+module A exposing (..)
+foo =
+    case maybeTupleMaybe of
+        Just ( bosh as bish ) ->
+            bosh + bish
+        _ ->
+            0
+"""
+                |> Review.Test.run rule
+                |> Review.Test.expectErrors
+                    [ Review.Test.error
+                        { message = "Unnecessary duplicate alias `bish`"
+                        , details = [ "This alias is redundant because the value is already named `bosh`. I suggest you remove one of them." ]
+                        , under = "bish"
+                        }
+                        |> Review.Test.atExactly { start = { row = 5, column = 24 }, end = { row = 5, column = 28 } }
+                    ]
     , test "should report duplicate aliases" <|
         \() ->
             """

--- a/tests/NoUnused/PatternsTest.elm
+++ b/tests/NoUnused/PatternsTest.elm
@@ -645,7 +645,7 @@ foo =
 module A exposing (..)
 foo =
     case maybeTupleMaybe of
-        Just ( _, (Just _) ) ->
+        Just ( _, Just _ ) ->
             bash
         _ ->
             bosh


### PR DESCRIPTION
Fixes #72 

- `NoUnused.Patterns` now reports multiple aliases `(((A a) as y) as z)`
- `NoUnused.Patterns` now reports aliases on a variable pattern `(name as otherName)`
- `NoUnused.Patterns` now reports aliases to wildcard `(_ as thing)` in parameters, and `NoUnused.Parameters` now doesn't.
- Slightly improved the fixes for `NoUnused.Patterns` to not include unnecessary patterns