### PR TITLE
Catch unused imported functions when shadowed in a tuple let declaration v2

### DIFF
--- a/src/NoUnused/Variables.elm
+++ b/src/NoUnused/Variables.elm
@@ -714,9 +714,24 @@ expressionEnterVisitor (Node range value) context =
                 (List.map (\( patternNode, _ ) -> patternNode) cases)
                 context
 
-        Expression.LetExpression _ ->
+        Expression.LetExpression letBlock ->
+            let
+                namesToIgnore : Set String
+                namesToIgnore =
+                    List.foldl
+                        (\declaration acc ->
+                            case Node.value declaration of
+                                Expression.LetFunction _ ->
+                                    acc
+
+                                Expression.LetDestructuring pattern _ ->
+                                    getDeclaredNamesFromPattern [ pattern ] acc
+                        )
+                        Set.empty
+                        letBlock.declarations
+            in
             { context
-                | scopes = NonemptyList.cons { declared = Dict.empty, used = Dict.empty, namesToIgnore = Set.empty } context.scopes
+                | scopes = NonemptyList.cons { declared = Dict.empty, used = Dict.empty, namesToIgnore = namesToIgnore } context.scopes
             }
 
         _ ->


### PR DESCRIPTION
Spun off from #91, the following report was discovered by @matzko

I noticed that if there is an unused imported function of the same name as a variable declared in a tuple, it doesn't get recognized as unused.

For example, `a` below:

```
module SomeModule exposing (b, bar)
import Foo exposing (a)

bar : Int
bar =
    let
        (a, c) = (1, 3)
    in
    a + c
```

@matzko I would appreciate your review (but no pressure), at least to see if this still correctly solves your original issue.